### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Build and push to DockerHub
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Flexpair/mumbling-mole/security/code-scanning/26](https://github.com/Flexpair/mumbling-mole/security/code-scanning/26)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (current and future unless overridden). The least-privilege fix for this workflow is:

- `contents: read`

This preserves current behavior (checkout and metadata reading still work) while ensuring the token cannot write by default if org/repo defaults are broader.

Edit file `.github/workflows/docker-image.yml` near the top-level keys (after `name` is a clean location), without changing any job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
