### PR TITLE
fix: declare non-submit buttons explicitly

### DIFF
--- a/app/components/ConnectionInfoDialog.vue
+++ b/app/components/ConnectionInfoDialog.vue
@@ -21,55 +21,55 @@
           >
             <button 
               ref="tabLatency"
+              type="button"
               :class="['nav-item', { active: activeTab === 'latency' }]"
               @click="selectTab('latency')"
               :tabindex="activeTab === 'latency' ? 0 : -1"
               role="tab"
               :aria-selected="activeTab === 'latency'"
               aria-controls="latency-panel"
-              type="button"
             >
               <span>Audio Delay</span>
             </button>
             <button 
               ref="tabBandwidth"
+              type="button"
               :class="['nav-item', { active: activeTab === 'bandwidth' }]"
               @click="selectTab('bandwidth')"
               :tabindex="activeTab === 'bandwidth' ? 0 : -1"
               role="tab"
               :aria-selected="activeTab === 'bandwidth'"
               aria-controls="bandwidth-panel"
-              type="button"
             >
               <span>Bandwidth</span>
             </button>
             <button 
               ref="tabClient"
+              type="button"
               :class="['nav-item', { active: activeTab === 'client' }]"
               @click="selectTab('client')"
               :tabindex="activeTab === 'client' ? 0 : -1"
               role="tab"
               :aria-selected="activeTab === 'client'"
               aria-controls="client-panel"
-              type="button"
             >
               <span>Client</span>
             </button>
             <button 
               ref="tabServer"
+              type="button"
               :class="['nav-item', { active: activeTab === 'server' }]"
               @click="selectTab('server')"
               :tabindex="activeTab === 'server' ? 0 : -1"
               role="tab"
               :aria-selected="activeTab === 'server'"
               aria-controls="server-panel"
-              type="button"
             >
               <span>Server</span>
             </button>
           </div>
           <div class="sidebar-footer">
-            <button class="close-button" @click="handleHide">
+            <button class="close-button" type="button" @click="handleHide">
               {{ t('settingsdialog.close') }}
             </button>
           </div>

--- a/app/components/MicPermissionRetryOverlay.vue
+++ b/app/components/MicPermissionRetryOverlay.vue
@@ -11,6 +11,7 @@
       <span id="mic-permission-title">Microphone access denied</span>
       <p v-if="errorMessage" id="mic-permission-desc" class="mic-permission-message">{{ errorMessage }}</p>
       <button 
+        type="button"
         @click="handleRetry" 
         class="mic-permission-button"
       >

--- a/app/components/connection-info/ClientTab.vue
+++ b/app/components/connection-info/ClientTab.vue
@@ -15,7 +15,7 @@
     <div v-if="voiceMode === 'ptt'" class="setting-group">
       <label class="setting-label" for="ptt-key-button">{{ t('settingsdialog.ptt_key') }}</label>
       <div class="control-wrapper">
-        <button id="ptt-key-button" class="ptt-record-btn" @click="recordPttKey">
+        <button id="ptt-key-button" class="ptt-record-btn" type="button" @click="recordPttKey">
           {{ pttKeyDisplay }}
         </button>
       </div>
@@ -23,7 +23,7 @@
 
     <div class="setting-group version-group">
       <span class="setting-label">Client Version</span>
-      <button @click="copyCommitHash" class="action-button" :title="copyButtonTitle">
+      <button type="button" @click="copyCommitHash" class="action-button" :title="copyButtonTitle">
         {{ copyButtonText }}
       </button>
     </div>


### PR DESCRIPTION
## Summary
- Declare non-submit buttons with `type="button"`
- Prevent accidental form submission for tabs and action buttons

## Verification
- `npm run build`
- `git diff --check`

SonarQube issue: javascript:S9011