### PR TITLE
fix(auth): harden login and connection handoff

### DIFF
--- a/__tests__/audio/audio-context-manager.test.js
+++ b/__tests__/audio/audio-context-manager.test.js
@@ -76,6 +76,7 @@ describe('AudioContextManager', () => {
     audioContextManager.onSuspendCallbacks = [];
     audioContextManager.onResumeCallbacks = [];
     audioContextManager.suspendRequest = null;
+    audioContextManager.transitionRequest = Promise.resolve();
   });
 
   afterEach(() => {
@@ -157,6 +158,7 @@ describe('AudioContextManager', () => {
     const suspend = audioContextManager.suspendAudioContext();
     const resume = audioContextManager.resumeAudioContext();
     await Promise.resolve();
+    await Promise.resolve();
     expect(context.resume).not.toHaveBeenCalled();
 
     resolveSuspend();
@@ -181,6 +183,7 @@ describe('AudioContextManager', () => {
     const secondSuspend = audioContextManager.suspendAudioContext();
     const resume = audioContextManager.resumeAudioContext();
     await Promise.resolve();
+    await Promise.resolve();
 
     expect(context.suspend).toHaveBeenCalledTimes(1);
     expect(context.resume).not.toHaveBeenCalled();
@@ -189,6 +192,29 @@ describe('AudioContextManager', () => {
     await Promise.all([firstSuspend, secondSuspend, resume]);
     expect(context.resume).toHaveBeenCalledTimes(1);
     expect(context.state).toBe('running');
+  });
+
+  test('suspends after a pending resume completes', async () => {
+    const context = await audioContextManager.getAudioContext();
+    let resolveResume;
+    context.resume.mockImplementationOnce(() => new Promise(resolve => {
+      resolveResume = () => {
+        context.state = 'running';
+        resolve();
+      };
+    }));
+
+    const resume = audioContextManager.resumeAudioContext();
+    const suspend = audioContextManager.suspendAudioContext();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(context.suspend).not.toHaveBeenCalled();
+
+    resolveResume();
+    await Promise.all([resume, suspend]);
+    expect(context.suspend).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe('suspended');
   });
 
   test('should detect user interaction and auto-resume', async () => {

--- a/__tests__/audio/audio-context-manager.test.js
+++ b/__tests__/audio/audio-context-manager.test.js
@@ -75,6 +75,7 @@ describe('AudioContextManager', () => {
     audioContextManager.onReadyCallbacks = [];
     audioContextManager.onSuspendCallbacks = [];
     audioContextManager.onResumeCallbacks = [];
+    audioContextManager.suspendRequest = null;
   });
 
   afterEach(() => {
@@ -138,6 +139,29 @@ describe('AudioContextManager', () => {
   test('should auto-resume on ensureAudioContext', async () => {
     const context = await ensureAudioContext({ sampleRate: 48000 });
     
+    expect(context.state).toBe('running');
+  });
+
+  test('waits for a pending suspension before resuming', async () => {
+    const context = await audioContextManager.getAudioContext();
+    await context.resume();
+    context.resume.mockClear();
+    let resolveSuspend;
+    context.suspend.mockImplementationOnce(() => new Promise(resolve => {
+      resolveSuspend = () => {
+        context.state = 'suspended';
+        resolve();
+      };
+    }));
+
+    const suspend = audioContextManager.suspendAudioContext();
+    const resume = audioContextManager.resumeAudioContext();
+    await Promise.resolve();
+    expect(context.resume).not.toHaveBeenCalled();
+
+    resolveSuspend();
+    await Promise.all([suspend, resume]);
+    expect(context.resume).toHaveBeenCalledTimes(1);
     expect(context.state).toBe('running');
   });
 

--- a/__tests__/audio/audio-context-manager.test.js
+++ b/__tests__/audio/audio-context-manager.test.js
@@ -165,6 +165,32 @@ describe('AudioContextManager', () => {
     expect(context.state).toBe('running');
   });
 
+  test('reuses a pending suspension before resuming', async () => {
+    const context = await audioContextManager.getAudioContext();
+    await context.resume();
+    context.resume.mockClear();
+    let resolveSuspend;
+    context.suspend.mockImplementationOnce(() => new Promise(resolve => {
+      resolveSuspend = () => {
+        context.state = 'suspended';
+        resolve();
+      };
+    }));
+
+    const firstSuspend = audioContextManager.suspendAudioContext();
+    const secondSuspend = audioContextManager.suspendAudioContext();
+    const resume = audioContextManager.resumeAudioContext();
+    await Promise.resolve();
+
+    expect(context.suspend).toHaveBeenCalledTimes(1);
+    expect(context.resume).not.toHaveBeenCalled();
+
+    resolveSuspend();
+    await Promise.all([firstSuspend, secondSuspend, resume]);
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe('running');
+  });
+
   test('should detect user interaction and auto-resume', async () => {
     const context = await audioContextManager.getAudioContext();
     expect(context.state).toBe('suspended');

--- a/__tests__/audio/voice.test.js
+++ b/__tests__/audio/voice.test.js
@@ -690,7 +690,8 @@ describe('initVoice Integration Tests', () => {
     // Mock MediaStreamTrack
     mockTrack = {
       addEventListener: jest.fn(),
-      removeEventListener: jest.fn()
+      removeEventListener: jest.fn(),
+      stop: jest.fn()
     };
 
     // Mock MediaStream
@@ -1014,6 +1015,35 @@ describe('initVoice Integration Tests', () => {
   });
 
   describe('Mixer Lifecycle & Race Conditions', () => {
+    test('should stop microphone tracks when capture is cancelled before permission resolves', async () => {
+      let resolveUserMedia;
+      mockGetUserMedia.mockImplementation(() => new Promise(resolve => {
+        resolveUserMedia = resolve;
+      }));
+
+      const stopCapture = initVoice(jest.fn(), jest.fn());
+      stopCapture();
+      resolveUserMedia(mockMediaStream);
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(mockTrack.stop).toHaveBeenCalledTimes(1);
+      expect(mockAudioContext.createMediaStreamSource).not.toHaveBeenCalled();
+    });
+
+    test('should disconnect the audio graph and stop tracks when capture is cancelled', async () => {
+      mockGetUserMedia.mockResolvedValue(mockMediaStream);
+
+      const stopCapture = initVoice(jest.fn(), jest.fn());
+      await new Promise(resolve => setTimeout(resolve, 50));
+      stopCapture();
+
+      expect(mockTrack.stop).toHaveBeenCalledTimes(1);
+      expect(mockAudioWorkletNode.disconnect).toHaveBeenCalled();
+      expect(mockGainNode.disconnect).toHaveBeenCalled();
+      expect(mockMediaStreamSource.disconnect).toHaveBeenCalled();
+      expect(globalThis._audioMixer).toBeNull();
+    });
+
     test('should track current mixer instance', async () => {
       mockGetUserMedia.mockResolvedValue(mockMediaStream);
 

--- a/__tests__/audio/voice.test.js
+++ b/__tests__/audio/voice.test.js
@@ -681,11 +681,13 @@ describe('initVoice Integration Tests', () => {
   let mockAudioWorkletNode;
   let consoleLogSpy;
   let consoleErrorSpy;
+  let consoleWarnSpy;
 
   beforeEach(() => {
     // Spy on console methods
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
     // Mock MediaStreamTrack
     mockTrack = {
@@ -750,6 +752,7 @@ describe('initVoice Integration Tests', () => {
   afterEach(() => {
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
     delete globalThis._audioMixer;
     delete globalThis.AudioWorkletNode;
     
@@ -1033,15 +1036,39 @@ describe('initVoice Integration Tests', () => {
     test('should disconnect the audio graph and stop tracks when capture is cancelled', async () => {
       mockGetUserMedia.mockResolvedValue(mockMediaStream);
 
-      const stopCapture = initVoice(jest.fn(), jest.fn());
+      const onData = jest.fn();
+      const stopCapture = initVoice(onData, jest.fn());
       await new Promise(resolve => setTimeout(resolve, 50));
+      const staleMessageHandler = mockAudioWorkletNode.port.onmessage;
       stopCapture();
 
       expect(mockTrack.stop).toHaveBeenCalledTimes(1);
       expect(mockAudioWorkletNode.disconnect).toHaveBeenCalled();
       expect(mockGainNode.disconnect).toHaveBeenCalled();
       expect(mockMediaStreamSource.disconnect).toHaveBeenCalled();
+      expect(mockAudioWorkletNode.port.onmessage).toBeNull();
+
+      staleMessageHandler({
+        data: { type: 'pcm', data: new Float32Array(960).buffer },
+      });
+      expect(onData).not.toHaveBeenCalled();
       expect(globalThis._audioMixer).toBeNull();
+    });
+
+    test('should handle asynchronous AudioContext suspension failures', async () => {
+      const suspensionError = new Error('Suspension failed');
+      mockAudioContextManager.suspendAudioContext.mockRejectedValueOnce(suspensionError);
+      mockGetUserMedia.mockResolvedValue(mockMediaStream);
+
+      const stopCapture = initVoice(jest.fn(), jest.fn());
+      await new Promise(resolve => setTimeout(resolve, 50));
+      stopCapture();
+      await Promise.resolve();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[VOICE] Error suspending AudioContext:',
+        suspensionError
+      );
     });
 
     test('should track current mixer instance', async () => {

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -684,6 +684,29 @@ describe('NetlifyIdentityAdapter - logout()', () => {
     expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
   });
 
+  test('aborting a stalled logout releases the queue and does not suppress its late event', async () => {
+    const appLogout = jest.fn();
+    const controller = new AbortController();
+    adapter.on('logout', appLogout);
+    adapter.netlifyIdentity.logout
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => emitLogout());
+
+    const stalledLogout = adapter.logout({
+      suppressProviderEvent: true,
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(stalledLogout).rejects.toMatchObject({ name: 'AbortError' });
+    emitLogout();
+    expect(appLogout).toHaveBeenCalledTimes(1);
+
+    await adapter.logout();
+    expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
+  });
+
 });
 
 describe('NetlifyIdentityAdapter - on() after init', () => {

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -231,7 +231,10 @@ describe('NetlifyIdentityAdapter - on() before init', () => {
     
     expect(adapter._pendingHandlers).toHaveLength(0);
     expect(mockNetlifyIdentity.on).toHaveBeenCalledWith('login', callback1);
-    expect(mockNetlifyIdentity.on).toHaveBeenCalledWith('logout', callback2);
+    const logoutHandler = mockNetlifyIdentity.on.mock.calls
+      .find(([event]) => event === 'logout')[1];
+    logoutHandler();
+    expect(callback2).toHaveBeenCalled();
   });
 });
 
@@ -616,6 +619,13 @@ describe('NetlifyIdentityAdapter - login()', () => {
 });
 
 describe('NetlifyIdentityAdapter - logout()', () => {
+  const emitLogout = () => {
+    const callbacks = adapter.netlifyIdentity.on.mock.calls
+      .filter(([event]) => event === 'logout')
+      .map(([, callback]) => callback);
+    callbacks.forEach(callback => callback());
+  };
+
   beforeEach(async () => {
     await setupTestEnvironment();
     await createInitializedAdapter();
@@ -627,23 +637,51 @@ describe('NetlifyIdentityAdapter - logout()', () => {
   });
 
   test('calls netlifyIdentity.logout and resolves on logout event', async () => {
-    adapter.netlifyIdentity.logout.mockImplementation(() => {
-      // Simulate the widget firing the 'logout' event after logout completes
-      const logoutCallback = adapter.netlifyIdentity.on.mock.calls.find(c => c[0] === 'logout')[1];
-      logoutCallback();
-    });
+    adapter.netlifyIdentity.logout.mockImplementation(() => emitLogout());
     await adapter.logout();
     expect(adapter.netlifyIdentity.logout).toHaveBeenCalled();
     expect(adapter.netlifyIdentity.off).toHaveBeenCalledWith('logout', expect.any(Function));
   });
 
   test('resolves after logout', async () => {
-    adapter.netlifyIdentity.logout.mockImplementation(() => {
-      const logoutCallback = adapter.netlifyIdentity.on.mock.calls.find(c => c[0] === 'logout')[1];
-      logoutCallback();
-    });
+    adapter.netlifyIdentity.logout.mockImplementation(() => emitLogout());
     const result = await adapter.logout();
     expect(result).toBeUndefined();
+  });
+
+  test('suppresses the provider event for a reauthentication logout', async () => {
+    const appLogout = jest.fn();
+    adapter.on('logout', appLogout);
+    adapter.netlifyIdentity.logout.mockImplementation(() => emitLogout());
+
+    await adapter.logout({ suppressProviderEvent: true });
+
+    expect(appLogout).not.toHaveBeenCalled();
+    const appHandler = adapter._logoutHandlerWrappers.get(appLogout);
+    appHandler();
+    expect(appLogout).toHaveBeenCalledTimes(1);
+  });
+
+  test('serializes an explicit logout behind a delayed reauthentication logout', async () => {
+    let emitDelayedLogout;
+    adapter.netlifyIdentity.logout
+      .mockImplementationOnce(() => {
+        emitDelayedLogout = emitLogout;
+      })
+      .mockImplementationOnce(() => emitLogout());
+
+    const reauthentication = adapter.logout({ suppressProviderEvent: true });
+    await Promise.resolve();
+    const explicitLogout = adapter.logout();
+    await Promise.resolve();
+
+    expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(1);
+
+    emitDelayedLogout();
+    await reauthentication;
+    await explicitLogout;
+
+    expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -673,7 +711,8 @@ describe('NetlifyIdentityAdapter - on() after init', () => {
     adapter.on('logout', callback2);
     
     expect(adapter.netlifyIdentity.on).toHaveBeenCalledWith('login', callback1);
-    expect(adapter.netlifyIdentity.on).toHaveBeenCalledWith('logout', callback2);
+    const logoutHandler = adapter._logoutHandlerWrappers.get(callback2);
+    expect(adapter.netlifyIdentity.on).toHaveBeenCalledWith('logout', logoutHandler);
   });
 });
 

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -683,6 +683,29 @@ describe('NetlifyIdentityAdapter - logout()', () => {
 
     expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
   });
+
+  test('releases a suppressed logout operation when it is aborted', async () => {
+    const appLogout = jest.fn();
+    const controller = new AbortController();
+    adapter.on('logout', appLogout);
+    adapter.netlifyIdentity.logout
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockImplementationOnce(() => emitLogout());
+
+    const reauthentication = adapter.logout({
+      suppressProviderEvent: true,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(reauthentication).rejects.toMatchObject({ name: 'AbortError' });
+    const appHandler = adapter._logoutHandlerWrappers.get(appLogout);
+    appHandler();
+    expect(appLogout).toHaveBeenCalledTimes(1);
+
+    await adapter.logout();
+    expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('NetlifyIdentityAdapter - on() after init', () => {

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -341,6 +341,32 @@ describe('NetlifyIdentityAdapter - currentUser() sync version', () => {
   });
 });
 
+describe('NetlifyIdentityAdapter - getAccessToken()', () => {
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    await createInitializedAdapter();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    delete globalThis.netlifyIdentity;
+  });
+
+  test('returns the provider access token', async () => {
+    adapter.netlifyIdentity.currentUser = jest.fn().mockReturnValue({
+      token: { access_token: 'access-token' },
+    });
+
+    await expect(adapter.getAccessToken()).resolves.toBe('access-token');
+  });
+
+  test('returns null when there is no authenticated user', async () => {
+    adapter.netlifyIdentity.currentUser = jest.fn().mockReturnValue(null);
+
+    await expect(adapter.getAccessToken()).resolves.toBeNull();
+  });
+});
+
 describe('NetlifyIdentityAdapter - openAuth()', () => {
   beforeEach(async () => {
     await setupTestEnvironment();

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -684,28 +684,6 @@ describe('NetlifyIdentityAdapter - logout()', () => {
     expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
   });
 
-  test('releases a suppressed logout operation when it is aborted', async () => {
-    const appLogout = jest.fn();
-    const controller = new AbortController();
-    adapter.on('logout', appLogout);
-    adapter.netlifyIdentity.logout
-      .mockImplementationOnce(() => new Promise(() => {}))
-      .mockImplementationOnce(() => emitLogout());
-
-    const reauthentication = adapter.logout({
-      suppressProviderEvent: true,
-      signal: controller.signal,
-    });
-    controller.abort();
-
-    await expect(reauthentication).rejects.toMatchObject({ name: 'AbortError' });
-    const appHandler = adapter._logoutHandlerWrappers.get(appLogout);
-    appHandler();
-    expect(appLogout).toHaveBeenCalledTimes(1);
-
-    await adapter.logout();
-    expect(adapter.netlifyIdentity.logout).toHaveBeenCalledTimes(2);
-  });
 });
 
 describe('NetlifyIdentityAdapter - on() after init', () => {

--- a/__tests__/auth/auth-modules.test.js
+++ b/__tests__/auth/auth-modules.test.js
@@ -31,6 +31,7 @@ class AuthenticatedTestProvider extends AuthProvider {
   }
   async init() { return; }
   async getCurrentUser() { return this._currentUser; }
+  async getAccessToken() { return this._currentUser?.accessToken || null; }
   async openAuth() { return; }
   async closeAuth() { return; }
   async signup() { return {}; }
@@ -72,6 +73,11 @@ describe('AuthProvider', () => {
     test('requires getCurrentUser() implementation', async () => {
       const provider = new IncompleteProvider();
       await expect(provider.getCurrentUser()).rejects.toThrow('must be implemented');
+    });
+
+    test('requires getAccessToken() implementation', async () => {
+      const provider = new IncompleteProvider();
+      await expect(provider.getAccessToken()).rejects.toThrow('must be implemented');
     });
 
     test('requires openAuth() implementation', async () => {

--- a/__tests__/auth/credentials-service.test.js
+++ b/__tests__/auth/credentials-service.test.js
@@ -76,6 +76,18 @@ describe('credentials-service', () => {
       expect(result).toEqual(validCredentials);
     });
 
+    it.each([
+      ['mumblePassword', { guacamoleUser: 'editor', guacamolePassword: 'guac-password' }],
+      ['guacamoleUser', { mumblePassword: 'test-password', guacamolePassword: 'guac-password' }],
+      ['guacamolePassword', { mumblePassword: 'test-password', guacamoleUser: 'editor' }],
+    ])('should reject credentials missing %s', async (_field, credentials) => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(credentials));
+
+      await expect(fetchCredentials('valid-jwt-token'))
+        .rejects.toThrow('Credentials response is incomplete');
+      expect(hasCredentials()).toBe(false);
+    });
+
     it('should cache credentials after successful fetch', async () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(validCredentials));
 
@@ -105,18 +117,44 @@ describe('credentials-service', () => {
       let resolveFirst;
       const firstResponse = new Promise(resolve => { resolveFirst = resolve; });
       mockFetch
-        .mockImplementationOnce(() => firstResponse.then(() => createMockResponse({ user: 'first' })))
-        .mockResolvedValueOnce(createMockResponse({ user: 'second' }));
+        .mockImplementationOnce(() => firstResponse.then(() => createMockResponse({
+          ...validCredentials,
+          guacamoleUser: 'first',
+        })))
+        .mockResolvedValueOnce(createMockResponse({
+          ...validCredentials,
+          guacamoleUser: 'second',
+        }));
 
       const firstRequest = fetchCredentials('token-a');
       const secondRequest = fetchCredentials('token-b');
 
-      await expect(secondRequest).resolves.toEqual({ user: 'second' });
+      await expect(secondRequest).resolves.toEqual({
+        ...validCredentials,
+        guacamoleUser: 'second',
+      });
       resolveFirst();
       await expect(firstRequest).rejects.toMatchObject({
         code: 'CREDENTIALS_REQUEST_SUPERSEDED'
       });
       expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should mask a stale request failure after the auth token changes', async () => {
+      let rejectFirst;
+      mockFetch
+        .mockImplementationOnce(() => new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }))
+        .mockResolvedValueOnce(createMockResponse(validCredentials));
+
+      const firstRequest = fetchCredentials('token-a');
+      await expect(fetchCredentials('token-b')).resolves.toEqual(validCredentials);
+      rejectFirst(new Error('old request failed'));
+
+      await expect(firstRequest).rejects.toMatchObject({
+        code: 'CREDENTIALS_REQUEST_SUPERSEDED'
+      });
     });
 
     it('should reject an in-flight request invalidated by clearCredentials', async () => {
@@ -193,7 +231,7 @@ describe('credentials-service', () => {
 
   describe('clearCredentials', () => {
     it('should clear cached credentials', async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ mumblePassword: 'test' }));
+      mockFetch.mockResolvedValueOnce(createMockResponse(validCredentials));
 
       await fetchCredentials('token');
       expect(hasCredentials()).toBe(true);
@@ -204,8 +242,8 @@ describe('credentials-service', () => {
     });
 
     it('should allow new fetch after clearing', async () => {
-      const creds1 = { mumblePassword: 'first' };
-      const creds2 = { mumblePassword: 'second' };
+      const creds1 = { ...validCredentials, mumblePassword: 'first' };
+      const creds2 = { ...validCredentials, mumblePassword: 'second' };
 
       mockFetch
         .mockResolvedValueOnce(createMockResponse(creds1))
@@ -227,7 +265,7 @@ describe('credentials-service', () => {
     });
 
     it('should return true after successful fetch', async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ mumblePassword: 'test' }));
+      mockFetch.mockResolvedValueOnce(createMockResponse(validCredentials));
 
       await fetchCredentials('token');
       expect(hasCredentials()).toBe(true);
@@ -238,7 +276,7 @@ describe('credentials-service', () => {
       let currentTime = 1000000;
       Date.now = jest.fn(() => currentTime);
       
-      mockFetch.mockResolvedValueOnce(createMockResponse({ mumblePassword: 'test' }));
+      mockFetch.mockResolvedValueOnce(createMockResponse(validCredentials));
 
       await fetchCredentials('token');
       expect(hasCredentials()).toBe(true);
@@ -255,7 +293,7 @@ describe('credentials-service', () => {
       let currentTime = 1000000;
       Date.now = jest.fn(() => currentTime);
       
-      mockFetch.mockResolvedValue(createMockResponse({ mumblePassword: 'test' }));
+      mockFetch.mockResolvedValue(createMockResponse(validCredentials));
 
       await fetchCredentials('token');
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -275,7 +313,7 @@ describe('credentials-service', () => {
     });
 
     it('should return credentials after fetch', async () => {
-      const creds = { mumblePassword: 'test', guacamoleUser: 'admin' };
+      const creds = { ...validCredentials, guacamoleUser: 'admin' };
       mockFetch.mockResolvedValueOnce(createMockResponse(creds));
 
       await fetchCredentials('token');

--- a/__tests__/auth/credentials-service.test.js
+++ b/__tests__/auth/credentials-service.test.js
@@ -113,8 +113,26 @@ describe('credentials-service', () => {
 
       await expect(secondRequest).resolves.toEqual({ user: 'second' });
       resolveFirst();
-      await expect(firstRequest).resolves.toEqual({ user: 'first' });
+      await expect(firstRequest).rejects.toMatchObject({
+        code: 'CREDENTIALS_REQUEST_SUPERSEDED'
+      });
       expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reject an in-flight request invalidated by clearCredentials', async () => {
+      let resolveFetch;
+      mockFetch.mockImplementationOnce(() => new Promise(resolve => {
+        resolveFetch = resolve;
+      }));
+
+      const request = fetchCredentials('token');
+      clearCredentials();
+      resolveFetch(createMockResponse(validCredentials));
+
+      await expect(request).rejects.toMatchObject({
+        code: 'CREDENTIALS_REQUEST_SUPERSEDED'
+      });
+      expect(getCachedCredentials()).toBeNull();
     });
 
     it('should bypass cache when forceRefresh is true', async () => {

--- a/__tests__/auth/credentials-service.test.js
+++ b/__tests__/auth/credentials-service.test.js
@@ -88,6 +88,35 @@ describe('credentials-service', () => {
       expect(cachedResult).toEqual(validCredentials);
     });
 
+    it('should not reuse credentials for a different token', async () => {
+      const firstCredentials = { ...validCredentials, guacamoleUser: 'first-user' };
+      const secondCredentials = { ...validCredentials, guacamoleUser: 'second-user' };
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse(firstCredentials))
+        .mockResolvedValueOnce(createMockResponse(secondCredentials));
+
+      await expect(fetchCredentials('token-a')).resolves.toEqual(firstCredentials);
+      await expect(fetchCredentials('token-b')).resolves.toEqual(secondCredentials);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not share a pending request between different tokens', async () => {
+      let resolveFirst;
+      const firstResponse = new Promise(resolve => { resolveFirst = resolve; });
+      mockFetch
+        .mockImplementationOnce(() => firstResponse.then(() => createMockResponse({ user: 'first' })))
+        .mockResolvedValueOnce(createMockResponse({ user: 'second' }));
+
+      const firstRequest = fetchCredentials('token-a');
+      const secondRequest = fetchCredentials('token-b');
+
+      await expect(secondRequest).resolves.toEqual({ user: 'second' });
+      resolveFirst();
+      await expect(firstRequest).resolves.toEqual({ user: 'first' });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('should bypass cache when forceRefresh is true', async () => {
       mockFetch.mockResolvedValue(createMockResponse(validCredentials));
 

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -103,6 +103,18 @@ describe('useAuthLogout', () => {
     jest.useRealTimers();
   });
 
+  test('uses provider-scoped suppression when the auth adapter supports it', async () => {
+    const auth = {
+      supportsLogoutEventSuppression: true,
+      logout: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await logoutForReauthentication(auth);
+
+    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: true });
+    expect(shouldHandleProviderLogout()).toBe(true);
+  });
+
   test('handles the next provider logout when reauthentication logout fails', async () => {
     const auth = { logout: jest.fn().mockRejectedValue(new Error('logout failed')) };
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -100,7 +100,10 @@ describe('useAuthLogout', () => {
     jest.advanceTimersByTime(1500);
     await expect(logout).resolves.toBe(false);
 
-    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: false });
+    expect(auth.logout).toHaveBeenCalledWith({
+      suppressProviderEvent: false,
+      signal: expect.any(AbortSignal),
+    });
     expect(reload).toHaveBeenCalledTimes(1);
     expect(shouldHandleProviderLogout()).toBe(true);
     jest.useRealTimers();
@@ -114,7 +117,10 @@ describe('useAuthLogout', () => {
 
     await logoutForReauthentication(auth);
 
-    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: true });
+    expect(auth.logout).toHaveBeenCalledWith({
+      suppressProviderEvent: true,
+      signal: expect.any(AbortSignal),
+    });
     expect(shouldHandleProviderLogout()).toBe(true);
   });
 

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -1,0 +1,92 @@
+import { jest } from '@jest/globals';
+
+const mockClearCredentials = jest.fn();
+const mockInvalidateConnectionAttempt = jest.fn();
+
+jest.unstable_mockModule('../../app/auth/credentials-service.js', () => ({
+  clearCredentials: mockClearCredentials,
+}));
+
+jest.unstable_mockModule('../../app/composables/connectionAttempt.js', () => ({
+  invalidateConnectionAttempt: mockInvalidateConnectionAttempt,
+}));
+
+const {
+  logoutForReauthentication,
+  logoutSession,
+  shouldHandleProviderLogout,
+} = await import('../../app/composables/useAuthLogout.js');
+
+describe('useAuthLogout', () => {
+  test('tears down local resources from the connect-dialog logout path', async () => {
+    const dependencies = {
+      auth: { logout: jest.fn().mockResolvedValue(undefined) },
+      uiStore: { guacamoleFrame: { stop: jest.fn() }, reset: jest.fn() },
+      audioStore: { stopBeep: jest.fn() },
+      voiceStore: { reset: jest.fn() },
+      connectionStore: { disconnect: jest.fn() },
+      userStore: { reset: jest.fn() },
+      dialogStore: { resetConnectDialog: jest.fn() },
+    };
+    const reload = jest.fn();
+    await logoutSession(dependencies, reload);
+
+    expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateConnectionAttempt).toHaveBeenCalledTimes(1);
+    expect(dependencies.uiStore.guacamoleFrame.stop).toHaveBeenCalledTimes(1);
+    expect(dependencies.audioStore.stopBeep).toHaveBeenCalledTimes(1);
+    expect(dependencies.voiceStore.reset).toHaveBeenCalledTimes(1);
+    expect(dependencies.connectionStore.disconnect).toHaveBeenCalledTimes(1);
+    expect(dependencies.userStore.reset).toHaveBeenCalledTimes(1);
+    expect(dependencies.dialogStore.resetConnectDialog).toHaveBeenCalledTimes(1);
+    expect(dependencies.auth.logout).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test('reloads when provider logout never settles', async () => {
+    jest.useFakeTimers();
+    const dependencies = {
+      auth: { logout: jest.fn(() => new Promise(() => {})) },
+      uiStore: { guacamoleFrame: null, reset: jest.fn() },
+      audioStore: { stopBeep: jest.fn() },
+      voiceStore: { reset: jest.fn() },
+      connectionStore: { disconnect: jest.fn() },
+      userStore: { reset: jest.fn() },
+    };
+    const reload = jest.fn();
+    const logout = logoutSession(dependencies, reload);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1500);
+    await logout;
+
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  test('ignores the delayed provider event from reauthentication logout once', async () => {
+    const auth = { logout: jest.fn().mockResolvedValue(undefined) };
+
+    await logoutForReauthentication(auth);
+
+    expect(shouldHandleProviderLogout()).toBe(false);
+    expect(shouldHandleProviderLogout()).toBe(true);
+  });
+
+  test('explicit logout cancels stale reauthentication suppression', async () => {
+    const auth = { logout: jest.fn().mockResolvedValue(undefined) };
+    const dependencies = {
+      auth,
+      uiStore: { guacamoleFrame: null, reset: jest.fn() },
+      audioStore: { stopBeep: jest.fn() },
+      voiceStore: { reset: jest.fn() },
+      connectionStore: { disconnect: jest.fn() },
+      userStore: { reset: jest.fn() },
+    };
+
+    await logoutForReauthentication(auth);
+    await logoutSession(dependencies, jest.fn());
+
+    expect(shouldHandleProviderLogout()).toBe(true);
+  });
+});

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -93,12 +93,15 @@ describe('useAuthLogout', () => {
   test('handles the next provider logout when reauthentication logout times out', async () => {
     jest.useFakeTimers();
     const auth = { logout: jest.fn(() => new Promise(() => {})) };
+    const reload = jest.fn();
 
-    const logout = logoutForReauthentication(auth);
+    const logout = logoutForReauthentication(auth, reload);
     await Promise.resolve();
     jest.advanceTimersByTime(1500);
-    await logout;
+    await expect(logout).resolves.toBe(false);
 
+    expect(auth.logout.mock.calls[0][0].signal.aborted).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
     expect(shouldHandleProviderLogout()).toBe(true);
     jest.useRealTimers();
   });
@@ -111,7 +114,10 @@ describe('useAuthLogout', () => {
 
     await logoutForReauthentication(auth);
 
-    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: true });
+    expect(auth.logout).toHaveBeenCalledWith({
+      suppressProviderEvent: true,
+      signal: expect.any(AbortSignal),
+    });
     expect(shouldHandleProviderLogout()).toBe(true);
   });
 

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -89,4 +89,27 @@ describe('useAuthLogout', () => {
 
     expect(shouldHandleProviderLogout()).toBe(true);
   });
+
+  test('handles the next provider logout when reauthentication logout times out', async () => {
+    jest.useFakeTimers();
+    const auth = { logout: jest.fn(() => new Promise(() => {})) };
+
+    const logout = logoutForReauthentication(auth);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1500);
+    await logout;
+
+    expect(shouldHandleProviderLogout()).toBe(true);
+    jest.useRealTimers();
+  });
+
+  test('handles the next provider logout when reauthentication logout fails', async () => {
+    const auth = { logout: jest.fn().mockRejectedValue(new Error('logout failed')) };
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await logoutForReauthentication(auth);
+
+    expect(shouldHandleProviderLogout()).toBe(true);
+    consoleError.mockRestore();
+  });
 });

--- a/__tests__/composables/useAuthLogout.test.js
+++ b/__tests__/composables/useAuthLogout.test.js
@@ -100,7 +100,7 @@ describe('useAuthLogout', () => {
     jest.advanceTimersByTime(1500);
     await expect(logout).resolves.toBe(false);
 
-    expect(auth.logout.mock.calls[0][0].signal.aborted).toBe(true);
+    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: false });
     expect(reload).toHaveBeenCalledTimes(1);
     expect(shouldHandleProviderLogout()).toBe(true);
     jest.useRealTimers();
@@ -114,10 +114,7 @@ describe('useAuthLogout', () => {
 
     await logoutForReauthentication(auth);
 
-    expect(auth.logout).toHaveBeenCalledWith({
-      suppressProviderEvent: true,
-      signal: expect.any(AbortSignal),
-    });
+    expect(auth.logout).toHaveBeenCalledWith({ suppressProviderEvent: true });
     expect(shouldHandleProviderLogout()).toBe(true);
   });
 

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -112,6 +112,10 @@ const mockUserStore = {
   thisUser: null,
   selfMute: false,
   registerUser: jest.fn(),
+  reset: jest.fn(() => {
+    mockUserStore.thisUser = null;
+    mockUserStore.selfMute = false;
+  }),
 };
 
 const mockSettingsStore = {
@@ -782,9 +786,10 @@ describe('useConnectionLogic', () => {
       expect(mockConnectionStore.disconnect).toHaveBeenCalled();
     });
 
-    it('should clear thisUser', () => {
+    it('should release registered users and their resources', () => {
       mockUserStore.thisUser = { session: 1 };
       logic.resetClient();
+      expect(mockUserStore.reset).toHaveBeenCalledTimes(1);
       expect(mockUserStore.thisUser).toBeNull();
     });
 

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -307,6 +307,38 @@ describe('useConnectionLogic', () => {
       expect(mockAuth.openAuth).not.toHaveBeenCalled();
     });
 
+    it('should not open stale reauthentication over a newer connection', async () => {
+      const staleLogout = deferred();
+      mockFetchCredentials
+        .mockRejectedValueOnce(new Error('Token expired'))
+        .mockResolvedValueOnce({
+          mumblePassword: 'current-password',
+          guacamoleUser: 'watcher',
+          guacamolePassword: 'current-guac-password',
+        });
+      mockLogoutForReauthentication.mockReturnValueOnce(staleLogout.promise);
+
+      const staleConnection = logic.connect('stale-host', 64738, 'stale-user', 'pass');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await useConnectionLogic({ auth: mockAuth })
+        .connect('current-host', 64738, 'current-user', 'pass');
+      staleLogout.resolve(true);
+      await staleConnection;
+
+      expect(mockAuth.openAuth).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).toHaveBeenCalledTimes(1);
+      expect(mockConnectionStore.connect).toHaveBeenCalledWith(
+        'current-host',
+        64738,
+        'current-user',
+        'current-password',
+        []
+      );
+    });
+
     it('should initialize audio context if not present', async () => {
       mockAudioStore.audioContext = null;
 

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -273,6 +273,24 @@ describe('useConnectionLogic', () => {
       expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 
+    it('should open login when provider logout never settles', async () => {
+      jest.useFakeTimers();
+      mockFetchCredentials.mockRejectedValue(new Error('Token expired'));
+      mockAuth.logout.mockReturnValue(new Promise(() => {}));
+
+      try {
+        const connection = logic.connect('host', 64738, 'user', 'pass');
+        await Promise.resolve();
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(1500);
+        await connection;
+
+        expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('should initialize audio context if not present', async () => {
       mockAudioStore.audioContext = null;
 

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -284,24 +284,6 @@ describe('useConnectionLogic', () => {
       expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 
-    it('should open login when provider logout never settles', async () => {
-      jest.useFakeTimers();
-      mockFetchCredentials.mockRejectedValue(new Error('Token expired'));
-      mockAuth.logout.mockReturnValue(new Promise(() => {}));
-
-      try {
-        const connection = logic.connect('host', 64738, 'user', 'pass');
-        await Promise.resolve();
-        await Promise.resolve();
-        await jest.advanceTimersByTimeAsync(1500);
-        await connection;
-
-        expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
     it('should not open login when reauthentication logout requires a reload', async () => {
       mockFetchCredentials.mockRejectedValue(new Error('Token expired'));
       mockLogoutForReauthentication.mockResolvedValueOnce(false);

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -261,12 +261,27 @@ describe('useConnectionLogic', () => {
       expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 
-    it('should initialize AudioContext if not present', async () => {
+    it('should initialize audio context if not present', async () => {
       mockAudioStore.audioContext = null;
-      
+
       await logic.connect('host', 64738, 'user', 'pass');
-      
+
       expect(mockAudioStore.initializeAudioContext).toHaveBeenCalled();
+    });
+
+    it('should roll back when AudioContext initialization returns no context', async () => {
+      mockAudioStore.audioContext = null;
+      mockAudioStore.initializeAudioContext.mockResolvedValueOnce(null);
+
+      await logic.connect('host', 64738, 'user', 'pass');
+
+      expect(mockDialogStore.showErrorDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('AudioContext') }),
+        expect.objectContaining({ host: 'host', port: 64738 })
+      );
+      expect(mockVoiceStore.endVoiceHandler).toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
     });
 
     it('should roll back and show an error when AudioContext initialization fails', async () => {
@@ -790,9 +805,10 @@ describe('useConnectionLogic', () => {
       mockVoiceStore.setupVoiceForConnection.mockImplementationOnce(() => voiceSetup.promise);
 
       const connection = logic.connect('h', 1, 'u', 'p');
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+      for (let attempt = 0; attempt < 10 && !mockVoiceStore.setupVoiceForConnection.mock.calls.length; attempt++) {
+        await Promise.resolve();
+      }
+      expect(mockVoiceStore.setupVoiceForConnection).toHaveBeenCalledTimes(1);
       logic.resetClient();
       voiceSetup.resolve(stopVoiceInput);
       await connection;

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -72,6 +72,17 @@ const mockAudioStore = {
   initializePersistentBeeper: jest.fn().mockResolvedValue(null),
   audioLockActive: false,
 };
+let cachedAudioContextRead;
+Object.defineProperty(mockAudioStore, 'audioContext', {
+  configurable: true,
+  get() {
+    cachedAudioContextRead?.();
+    return this._audioContext;
+  },
+  set(value) {
+    this._audioContext = value;
+  },
+});
 
 const mockVoiceStore = {
   isLoopbackMode: false,
@@ -176,6 +187,7 @@ describe('useConnectionLogic', () => {
     mockUserStore.thisUser = null;
     mockVoiceStore.isLoopbackMode = false;
     mockAudioStore.audioContext = { sampleRate: 48000 };
+    cachedAudioContextRead = undefined;
     mockAudioStore.micPermissionDenied = false;
     mockAudioStore.beeperReady = false;
     mockVoiceStore.voiceHandlerReady = false;
@@ -417,6 +429,16 @@ describe('useConnectionLogic', () => {
       expect(mockVoiceStore.setupVoiceForConnection).not.toHaveBeenCalled();
       expect(mockConnectionStore.connect).not.toHaveBeenCalled();
       expect(mockStartGuacamoleFrame).not.toHaveBeenCalled();
+    });
+
+    it('should stop before the sample-rate handoff when a cached AudioContext attempt is stale', async () => {
+      mockAudioStore.audioContext = { sampleRate: 44100 };
+      cachedAudioContextRead = () => logic.resetClient();
+
+      await logic.connect('old-host', 64738, 'old-user', 'pass');
+
+      expect(mockDialogStore.showSampleRateDialog).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
     });
 
     it('should stop existing microphone capture as soon as a new attempt starts', async () => {

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -418,6 +418,22 @@ describe('useConnectionLogic', () => {
       expect(mockVoiceStore.setupVoiceForConnection).toHaveBeenCalledWith(true, null);
     });
 
+    it('should show an error when voice setup fails', async () => {
+      const setupError = new Error('Audio setup failed');
+      mockVoiceStore.setupVoiceForConnection.mockRejectedValueOnce(setupError);
+
+      await logic.performConnect(
+        { host: 'h', port: 1, username: 'u', password: 'p' },
+        { audioEnabled: true }
+      );
+
+      expect(mockDialogStore.showErrorDialog).toHaveBeenCalledWith(
+        setupError,
+        expect.objectContaining({ host: 'h', port: 1 })
+      );
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+    });
+
     it('should set loopback mode if specified', async () => {
       await logic.performConnect({ host: 'h', port: 1, username: 'u', password: 'p', isLoopback: true }, {});
       

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -629,6 +629,23 @@ describe('useConnectionLogic', () => {
       expect(mockVoiceStore.isLoopbackMode).toBe(true);
     });
 
+    it('should keep the audio test active while connecting', async () => {
+      const identity = deferred();
+      const pendingAuth = {
+        ...mockAuth,
+        getCurrentUser: jest.fn(() => identity.promise),
+      };
+      mockDialogStore.connectDialog.isTestActive = true;
+
+      const connection = useConnectionLogic({ auth: pendingAuth })
+        .connectLoopback('host', 64738, 'user', 'pass');
+
+      expect(mockDialogStore.connectDialog.isTestActive).toBe(true);
+
+      identity.resolve(null);
+      await connection;
+    });
+
     it('should skip sample rate check in loopback mode', async () => {
       mockAudioStore.audioContext = { sampleRate: 44100 };
       

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -188,6 +188,7 @@ describe('useConnectionLogic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLogoutForReauthentication.mockResolvedValue(true);
     
     // Reset store state
     mockUserStore.thisUser = null;
@@ -295,6 +296,15 @@ describe('useConnectionLogic', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('should not open login when reauthentication logout requires a reload', async () => {
+      mockFetchCredentials.mockRejectedValue(new Error('Token expired'));
+      mockLogoutForReauthentication.mockResolvedValueOnce(false);
+
+      await logic.connect('host', 64738, 'user', 'pass');
+
+      expect(mockAuth.openAuth).not.toHaveBeenCalled();
     });
 
     it('should initialize audio context if not present', async () => {

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -564,6 +564,35 @@ describe('useConnectionLogic', () => {
       }
     });
 
+    it('should ignore a stale message confirmation timer after a replacement connection starts', async () => {
+      jest.useFakeTimers();
+      const staleClient = createClient('stale-user');
+      const currentClient = createClient('current-user');
+      mockConnectionStore.connect
+        .mockResolvedValueOnce(staleClient)
+        .mockResolvedValueOnce(currentClient);
+
+      try {
+        await logic.connect('stale-host', 64738, 'stale-user', 'pass');
+        const staleMessageHandler = staleClient.on.mock.calls
+          .find(([eventName]) => eventName === 'messageSent')[1];
+        staleMessageHandler('stale message');
+        jest.advanceTimersByTime(1000);
+
+        const currentLogic = useConnectionLogic({ auth: mockAuth });
+        await currentLogic.connect('current-host', 64738, 'current-user', 'pass');
+        const currentMessageHandler = currentClient.on.mock.calls
+          .find(([eventName]) => eventName === 'messageSent')[1];
+        currentMessageHandler('current message');
+
+        jest.advanceTimersByTime(1000);
+
+        expect(mockUIStore.messageConfirmed).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('should ignore a stale unauthenticated session lookup after a newer connection succeeds', async () => {
       const staleIdentity = deferred();
       const staleAuth = {

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -68,6 +68,7 @@ const mockAudioStore = {
   micPermissionDenied: false,
   clearAudioLock: jest.fn(),
   stopBeep: jest.fn(),
+  resetBeeper: jest.fn(),
   beeperReady: false,
   initializePersistentBeeper: jest.fn().mockResolvedValue(null),
   audioLockActive: false,
@@ -168,9 +169,14 @@ jest.unstable_mockModule('../../app/auth/credentials-service.js', () => ({
 }));
 
 const mockStartGuacamoleFrame = jest.fn();
+const mockLogoutForReauthentication = jest.fn().mockResolvedValue(undefined);
 
 jest.unstable_mockModule('../../app/composables/useGuacamole.js', () => ({
   startGuacamoleFrame: mockStartGuacamoleFrame,
+}));
+
+jest.unstable_mockModule('../../app/composables/useAuthLogout.js', () => ({
+  logoutForReauthentication: mockLogoutForReauthentication,
 }));
 
 const { useConnectionLogic } = await import('../../app/composables/useConnectionLogic.js');
@@ -269,7 +275,7 @@ describe('useConnectionLogic', () => {
       expect(globalThis.alert).toHaveBeenCalledWith(
         'Failed to authenticate. Please log in again.'
       );
-      expect(mockAuth.logout).toHaveBeenCalled();
+      expect(mockLogoutForReauthentication).toHaveBeenCalledWith(mockAuth);
       expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -534,6 +534,36 @@ describe('useConnectionLogic', () => {
       );
     });
 
+    it('should ignore queued client events after a replacement connection starts', async () => {
+      jest.useFakeTimers();
+      const staleClient = createClient('stale-user');
+      const currentClient = createClient('current-user');
+      mockConnectionStore.connect
+        .mockResolvedValueOnce(staleClient)
+        .mockResolvedValueOnce(currentClient);
+
+      try {
+        await logic.connect('stale-host', 64738, 'stale-user', 'pass');
+        const staleNewUserHandler = staleClient.on.mock.calls
+          .find(([eventName]) => eventName === 'newUser')[1];
+        const staleMessageHandler = staleClient.on.mock.calls
+          .find(([eventName]) => eventName === 'messageSent')[1];
+
+        await logic.connect('current-host', 64738, 'current-user', 'pass');
+        mockUserStore.registerUser.mockClear();
+        mockUIStore.messageConfirmed = false;
+
+        staleNewUserHandler({ session: 99, username: 'late-user' });
+        staleMessageHandler('late message');
+
+        expect(mockUserStore.registerUser).not.toHaveBeenCalled();
+        expect(mockUIStore.messageConfirmed).toBe(false);
+        expect(jest.getTimerCount()).toBe(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('should ignore a stale unauthenticated session lookup after a newer connection succeeds', async () => {
       const staleIdentity = deferred();
       const staleAuth = {

--- a/__tests__/composables/useConnectionLogic.test.js
+++ b/__tests__/composables/useConnectionLogic.test.js
@@ -40,6 +40,28 @@ const mockConnectionStore = {
   registerChannel: jest.fn(),
 };
 
+function createClient(name) {
+  return {
+    name,
+    root: { name: 'Root' },
+    self: { session: 1, username: name, __ui: {} },
+    users: new Map(),
+    setAudioQuality: jest.fn(),
+    on: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const mockAudioStore = {
   audioContext: { sampleRate: 48000 },
   initializeAudioContext: jest.fn().mockResolvedValue({}),
@@ -59,6 +81,13 @@ const mockVoiceStore = {
   updateVoiceHandler: jest.fn(),
   setMute: jest.fn(),
   endVoiceHandler: jest.fn(),
+  stopVoiceCapture: jest.fn(),
+  reset: jest.fn(() => {
+    mockVoiceStore.stopVoiceCapture();
+    mockVoiceStore.endVoiceHandler();
+    mockVoiceStore.isLoopbackMode = false;
+    mockVoiceStore.voiceHandlerReady = false;
+  }),
   loopbackDominantFrequency: 0,
 };
 
@@ -79,7 +108,9 @@ const mockSettingsStore = {
 };
 
 const mockDialogStore = {
+  connectDialog: { isTestActive: false },
   sampleRateDialog: { sampleRate: null, connectionParams: null },
+  showConnectDialog: jest.fn(),
   showSampleRateDialog: jest.fn(),
   showErrorDialog: jest.fn(),
 };
@@ -125,6 +156,12 @@ jest.unstable_mockModule('../../app/auth/credentials-service.js', () => ({
   clearCredentials: mockClearCredentials
 }));
 
+const mockStartGuacamoleFrame = jest.fn();
+
+jest.unstable_mockModule('../../app/composables/useGuacamole.js', () => ({
+  startGuacamoleFrame: mockStartGuacamoleFrame,
+}));
+
 const { useConnectionLogic } = await import('../../app/composables/useConnectionLogic.js');
 
 describe('useConnectionLogic', () => {
@@ -142,18 +179,27 @@ describe('useConnectionLogic', () => {
     mockAudioStore.micPermissionDenied = false;
     mockAudioStore.beeperReady = false;
     mockVoiceStore.voiceHandlerReady = false;
+    mockUIStore.guacamoleFrame = null;
+    mockDialogStore.connectDialog.isTestActive = false;
+    mockConnectionStore.connect.mockResolvedValue(createClient('default'));
+    mockConnectionStore.getClient.mockReturnValue(null);
     
     mockAuth = {
       currentUser: jest.fn(() => ({
+        id: 'test-user',
         token: { access_token: 'test-jwt-token' },
         app_metadata: {
           roles: ['watch', 'listen'],
         },
       })),
-      logout: jest.fn(),
+      getCurrentUser: jest.fn(async () => mockAuth.currentUser()),
+      getAccessToken: jest.fn().mockResolvedValue('test-jwt-token'),
+      openAuth: jest.fn().mockResolvedValue(undefined),
+      logout: jest.fn().mockResolvedValue(undefined),
     };
     
     // Reset credentials mock
+    mockFetchCredentials.mockReset();
     mockFetchCredentials.mockResolvedValue({
       mumblePassword: 'test-password',
       guacamoleUser: 'watcher',
@@ -170,35 +216,6 @@ describe('useConnectionLogic', () => {
     globalThis.alert = originalAlert;
   });
 
-  describe('getGuacamoleLogin', () => {
-    it('should return admin for admin role', () => {
-      expect(logic.getGuacamoleLogin(['admin'])).toBe('admin');
-    });
-
-    it('should return editor for edit role', () => {
-      expect(logic.getGuacamoleLogin(['edit'])).toBe('editor');
-    });
-
-    it('should return watcher for watch role', () => {
-      expect(logic.getGuacamoleLogin(['watch'])).toBe('watcher');
-    });
-
-    it('should return false for no matching role', () => {
-      expect(logic.getGuacamoleLogin(['other'])).toBe(false);
-    });
-
-    it('should return false for empty roles', () => {
-      expect(logic.getGuacamoleLogin([])).toBe(false);
-    });
-
-    it('should return false for undefined roles', () => {
-      expect(logic.getGuacamoleLogin()).toBe(false);
-    });
-
-    it('should prioritize admin over other roles', () => {
-      expect(logic.getGuacamoleLogin(['watch', 'admin', 'edit'])).toBe('admin');
-    });
-  });
 
   describe('connected()', () => {
     it('should return false when not connected', () => {
@@ -228,9 +245,8 @@ describe('useConnectionLogic', () => {
       
       await logic.connect('host', 64738, 'user', 'pass');
       
-      expect(globalThis.alert).toHaveBeenCalledWith(
-        'You do not have permission to connect to the server. Please contact the administrator.'
-      );
+      expect(globalThis.alert).toHaveBeenCalledWith('Failed to authenticate. Please log in again.');
+      expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 
     it('should alert when credentials fetch fails', async () => {
@@ -242,6 +258,7 @@ describe('useConnectionLogic', () => {
         'Failed to authenticate. Please log in again.'
       );
       expect(mockAuth.logout).toHaveBeenCalled();
+      expect(mockAuth.openAuth).toHaveBeenCalledWith('login');
     });
 
     it('should initialize AudioContext if not present', async () => {
@@ -250,6 +267,22 @@ describe('useConnectionLogic', () => {
       await logic.connect('host', 64738, 'user', 'pass');
       
       expect(mockAudioStore.initializeAudioContext).toHaveBeenCalled();
+    });
+
+    it('should roll back and show an error when AudioContext initialization fails', async () => {
+      const audioError = new Error('Audio initialization failed');
+      mockAudioStore.audioContext = null;
+      mockAudioStore.initializeAudioContext.mockRejectedValueOnce(audioError);
+
+      await logic.connect('host', 64738, 'user', 'pass');
+
+      expect(mockDialogStore.showErrorDialog).toHaveBeenCalledWith(
+        audioError,
+        expect.objectContaining({ host: 'host', port: 64738 })
+      );
+      expect(mockVoiceStore.endVoiceHandler).toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
     });
 
     it('should show sample rate dialog for non-48kHz', async () => {
@@ -268,6 +301,269 @@ describe('useConnectionLogic', () => {
       
       expect(mockDialogStore.showSampleRateDialog).not.toHaveBeenCalled();
       expect(mockVoiceStore.setupVoiceForConnection).toHaveBeenCalled();
+    });
+
+    it('should replace an active loopback connection through the normal pipeline', async () => {
+      mockVoiceStore.isLoopbackMode = true;
+      mockUserStore.thisUser = { session: 1 };
+
+      await logic.connect('host', 64738, 'user', 'dialog-password');
+
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockVoiceStore.isLoopbackMode).toBe(false);
+      expect(mockConnectionStore.connect).toHaveBeenCalledWith(
+        'host',
+        64738,
+        'user',
+        'test-password',
+        []
+      );
+      expect(mockStartGuacamoleFrame).toHaveBeenCalledWith(
+        'watcher',
+        'guac-password',
+        mockUIStore
+      );
+    });
+
+    it('should roll back Mumble when Guacamole startup fails', async () => {
+      const guacamoleError = new Error('Remote desktop is not ready');
+      mockStartGuacamoleFrame.mockRejectedValueOnce(guacamoleError);
+
+      await logic.connect('host', 64738, 'user', 'dialog-password');
+
+      expect(mockConnectionStore.connect).toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockDialogStore.showErrorDialog).toHaveBeenCalledWith(
+        guacamoleError,
+        expect.objectContaining({ host: 'host', port: 64738 })
+      );
+    });
+
+    it('should tear down Mumble and Guacamole when the auth session changes during remote desktop startup', async () => {
+      const guacamoleStarted = deferred();
+      const guacamoleReady = deferred();
+      let guacamoleStartupActive = false;
+      const stopGuacamole = jest.fn(() => {
+        if (!guacamoleStartupActive) return;
+        guacamoleStartupActive = false;
+        const cancelled = new Error('Remote desktop startup was cancelled');
+        cancelled.code = 'GUACAMOLE_START_CANCELLED';
+        guacamoleReady.reject(cancelled);
+      });
+      mockUIStore.guacamoleFrame = { stop: stopGuacamole };
+      mockStartGuacamoleFrame.mockImplementationOnce(() => {
+        guacamoleStartupActive = true;
+        guacamoleStarted.resolve();
+        return guacamoleReady.promise;
+      });
+
+      const connection = logic.connect('host', 64738, 'user', 'pass');
+      await guacamoleStarted.promise;
+      expect(mockStartGuacamoleFrame).toHaveBeenCalledTimes(1);
+      const stopCallsBeforeReset = stopGuacamole.mock.calls.length;
+      const disconnectCallsBeforeReset = mockConnectionStore.disconnect.mock.calls.length;
+
+      logic.resetClient();
+      await connection;
+
+      expect(stopGuacamole).toHaveBeenCalledTimes(stopCallsBeforeReset + 1);
+      expect(mockConnectionStore.disconnect)
+        .toHaveBeenCalledTimes(disconnectCallsBeforeReset + 1);
+      expect(mockUserStore.thisUser).toBeNull();
+      expect(mockDialogStore.showErrorDialog).not.toHaveBeenCalled();
+    });
+
+    it('should stop after credentials when the auth session changes', async () => {
+      mockFetchCredentials.mockImplementationOnce(async () => {
+        logic.resetClient();
+        return {
+          mumblePassword: 'old-password',
+          guacamoleUser: 'watcher',
+          guacamolePassword: 'old-guac-password',
+        };
+      });
+
+      await logic.connect('host', 64738, 'user', 'pass');
+
+      expect(mockVoiceStore.setupVoiceForConnection).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+      expect(mockStartGuacamoleFrame).not.toHaveBeenCalled();
+    });
+
+    it('should stop after audio initialization when the user logs out', async () => {
+      mockAudioStore.audioContext = null;
+      mockAudioStore.initializeAudioContext.mockImplementationOnce(async () => {
+        logic.resetClient();
+        mockAudioStore.audioContext = { sampleRate: 48000 };
+      });
+
+      await logic.connect('host', 64738, 'user', 'pass');
+
+      expect(mockVoiceStore.setupVoiceForConnection).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+      expect(mockStartGuacamoleFrame).not.toHaveBeenCalled();
+    });
+
+    it('should stop existing microphone capture as soon as a new attempt starts', async () => {
+      const identity = deferred();
+      const nextAuth = {
+        ...mockAuth,
+        getCurrentUser: jest.fn(() => identity.promise),
+      };
+      mockVoiceStore.stopVoiceCapture.mockClear();
+
+      const connection = useConnectionLogic({ auth: nextAuth })
+        .connect('next-host', 64738, 'next-user', 'pass');
+
+      expect(mockVoiceStore.stopVoiceCapture).toHaveBeenCalledTimes(1);
+
+      identity.resolve(null);
+      await connection;
+    });
+
+    it('should let only the newest connection attempt reach Mumble and Guacamole', async () => {
+      const firstCredentials = deferred();
+      const secondAuth = {
+        ...mockAuth,
+        getAccessToken: jest.fn().mockResolvedValue('new-session-token'),
+      };
+      mockAuth.getAccessToken.mockResolvedValue('old-session-token');
+      mockFetchCredentials.mockImplementation(token => token === 'old-session-token'
+        ? firstCredentials.promise
+        : Promise.resolve({
+          mumblePassword: 'new-password',
+          guacamoleUser: 'watcher',
+          guacamolePassword: 'new-guac-password',
+        }));
+
+      const firstConnection = logic.connect('old-host', 64738, 'old-user', 'pass');
+      const otherLogic = useConnectionLogic({ auth: secondAuth });
+      const secondConnection = otherLogic.connect('new-host', 64738, 'new-user', 'pass');
+      await secondConnection;
+      firstCredentials.resolve({
+        mumblePassword: 'old-password',
+        guacamoleUser: 'watcher',
+        guacamolePassword: 'old-guac-password',
+      });
+      await firstConnection;
+
+      expect(mockConnectionStore.connect).toHaveBeenCalledTimes(1);
+      expect(mockConnectionStore.connect).toHaveBeenCalledWith(
+        'new-host',
+        64738,
+        'new-user',
+        'new-password',
+        []
+      );
+      expect(mockStartGuacamoleFrame).toHaveBeenCalledTimes(1);
+      expect(mockStartGuacamoleFrame).toHaveBeenCalledWith(
+        'watcher',
+        'new-guac-password',
+        mockUIStore
+      );
+    });
+
+    it('should ignore a stale unauthenticated session lookup after a newer connection succeeds', async () => {
+      const staleIdentity = deferred();
+      const staleAuth = {
+        ...mockAuth,
+        getCurrentUser: jest.fn(() => staleIdentity.promise),
+        openAuth: jest.fn().mockResolvedValue(undefined),
+      };
+      const currentAuth = {
+        ...mockAuth,
+        getCurrentUser: jest.fn().mockResolvedValue({ id: 'current-user' }),
+        getAccessToken: jest.fn().mockResolvedValue('current-token'),
+      };
+
+      const staleConnection = useConnectionLogic({ auth: staleAuth })
+        .connect('stale-host', 64738, 'stale-user', 'pass');
+      await useConnectionLogic({ auth: currentAuth })
+        .connect('current-host', 64738, 'current-user', 'pass');
+
+      staleIdentity.resolve(null);
+      await staleConnection;
+
+      expect(staleAuth.openAuth).not.toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockConnectionStore.connect).toHaveBeenCalledTimes(1);
+      expect(mockConnectionStore.connect).toHaveBeenCalledWith(
+        'current-host',
+        64738,
+        'current-user',
+        'test-password',
+        []
+      );
+    });
+
+    it('should ignore a stale token lookup without superseding the newer credentials request', async () => {
+      const staleToken = deferred();
+      const currentCredentials = deferred();
+      const staleAuth = {
+        ...mockAuth,
+        getAccessToken: jest.fn(() => staleToken.promise),
+      };
+      const currentAuth = {
+        ...mockAuth,
+        getAccessToken: jest.fn().mockResolvedValue('current-token'),
+      };
+      mockFetchCredentials.mockImplementation(token => {
+        if (token === 'current-token') return currentCredentials.promise;
+        return Promise.reject(new Error('stale token must not be fetched'));
+      });
+
+      const staleConnection = useConnectionLogic({ auth: staleAuth })
+        .connect('stale-host', 64738, 'stale-user', 'pass');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(staleAuth.getAccessToken).toHaveBeenCalledTimes(1);
+
+      const currentConnection = useConnectionLogic({ auth: currentAuth })
+        .connect('current-host', 64738, 'current-user', 'pass');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      staleToken.resolve('stale-token');
+      currentCredentials.resolve({
+        mumblePassword: 'current-password',
+        guacamoleUser: 'watcher',
+        guacamolePassword: 'current-guac-password',
+      });
+      await Promise.all([staleConnection, currentConnection]);
+
+      expect(mockFetchCredentials).toHaveBeenCalledTimes(1);
+      expect(mockFetchCredentials).toHaveBeenCalledWith('current-token');
+      expect(mockConnectionStore.connect).toHaveBeenCalledTimes(1);
+      expect(mockConnectionStore.connect).toHaveBeenCalledWith(
+        'current-host',
+        64738,
+        'current-user',
+        'current-password',
+        []
+      );
+    });
+
+    it('should clear a stored client superseded before post-connect setup', async () => {
+      const nextIdentity = deferred();
+      const staleClient = createClient('stale');
+      const nextAuth = {
+        ...mockAuth,
+        getCurrentUser: jest.fn(() => nextIdentity.promise),
+      };
+      let nextConnection;
+
+      mockConnectionStore.connect.mockImplementationOnce(async () => {
+        mockConnectionStore.getClient.mockReturnValue(staleClient);
+        nextConnection = useConnectionLogic({ auth: nextAuth })
+          .connect('next-host', 64738, 'next-user', 'pass');
+        return staleClient;
+      });
+
+      await logic.connect('stale-host', 64738, 'stale-user', 'pass');
+
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      nextIdentity.resolve(null);
+      await nextConnection;
     });
   });
 
@@ -413,7 +709,7 @@ describe('useConnectionLogic', () => {
 
   describe('performConnect()', () => {
     it('should setup voice for connection', async () => {
-      await logic.performConnect({ host: 'h', port: 1, username: 'u', password: 'p' }, { audioEnabled: true });
+      await logic.connect('h', 1, 'u', 'p');
       
       expect(mockVoiceStore.setupVoiceForConnection).toHaveBeenCalledWith(true, null);
     });
@@ -422,28 +718,94 @@ describe('useConnectionLogic', () => {
       const setupError = new Error('Audio setup failed');
       mockVoiceStore.setupVoiceForConnection.mockRejectedValueOnce(setupError);
 
-      await logic.performConnect(
-        { host: 'h', port: 1, username: 'u', password: 'p' },
-        { audioEnabled: true }
-      );
+      await logic.connect('h', 1, 'u', 'p');
 
       expect(mockDialogStore.showErrorDialog).toHaveBeenCalledWith(
         setupError,
         expect.objectContaining({ host: 'h', port: 1 })
       );
       expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+      expect(mockVoiceStore.endVoiceHandler).toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+    });
+
+    it('should wait for voice capture readiness before connecting Mumble', async () => {
+      const voiceReady = deferred();
+      mockVoiceStore.setupVoiceForConnection.mockReturnValueOnce(voiceReady.promise);
+
+      const connection = logic.connect('h', 1, 'u', 'p');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+      expect(mockStartGuacamoleFrame).not.toHaveBeenCalled();
+
+      voiceReady.resolve(jest.fn());
+      await connection;
+      expect(mockConnectionStore.connect).toHaveBeenCalledTimes(1);
     });
 
     it('should set loopback mode if specified', async () => {
-      await logic.performConnect({ host: 'h', port: 1, username: 'u', password: 'p', isLoopback: true }, {});
+      await logic.connectLoopback('h', 1, 'u', 'p');
       
       expect(mockVoiceStore.isLoopbackMode).toBe(true);
+    });
+
+    it('should reject a dialog continuation after its auth session changes', async () => {
+      mockAudioStore.audioContext = { sampleRate: 44100 };
+      await logic.connect('h', 1, 'u', 'p');
+      const connectionParams = mockDialogStore.sampleRateDialog.connectionParams;
+      logic.resetClient();
+
+      jest.clearAllMocks();
+      await logic.performConnect(connectionParams, { audioEnabled: false });
+
+      expect(mockVoiceStore.setupVoiceForConnection).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+      expect(mockStartGuacamoleFrame).not.toHaveBeenCalled();
+    });
+
+    it('should cancel the pending sample-rate continuation and restore the retry dialog', async () => {
+      mockAudioStore.audioContext = { sampleRate: 44100 };
+      await logic.connect('h', 1, 'u', 'p');
+      const connectionParams = mockDialogStore.sampleRateDialog.connectionParams;
+
+      logic.cancelConnect(connectionParams);
+
+      expect(mockClearCredentials).toHaveBeenCalled();
+      expect(mockVoiceStore.endVoiceHandler).toHaveBeenCalled();
+      expect(mockDialogStore.showConnectDialog).toHaveBeenCalledTimes(1);
+      jest.clearAllMocks();
+
+      await logic.performConnect(connectionParams, { audioEnabled: false });
+
+      expect(mockVoiceStore.setupVoiceForConnection).not.toHaveBeenCalled();
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
+    });
+
+    it('should stop attempt-owned voice capture when superseded during setup', async () => {
+      const voiceSetup = deferred();
+      const stopVoiceInput = jest.fn();
+      mockVoiceStore.setupVoiceForConnection.mockImplementationOnce(() => voiceSetup.promise);
+
+      const connection = logic.connect('h', 1, 'u', 'p');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      logic.resetClient();
+      voiceSetup.resolve(stopVoiceInput);
+      await connection;
+
+      expect(stopVoiceInput).toHaveBeenCalledTimes(1);
+      expect(mockConnectionStore.connect).not.toHaveBeenCalled();
     });
   });
 
   describe('connect() edge cases', () => {
     it('should alert when user has no app_metadata', async () => {
-      mockAuth.currentUser.mockReturnValue({ app_metadata: null });
+      mockAuth.getCurrentUser.mockResolvedValueOnce({ id: 'test-user' });
+      mockAuth.getAccessToken.mockResolvedValueOnce(null);
       
       await logic.connect('host', 1234, 'user', 'pass');
       
@@ -451,10 +813,7 @@ describe('useConnectionLogic', () => {
     });
 
     it('should handle user without access_token gracefully', async () => {
-      mockAuth.currentUser.mockReturnValue({ 
-        app_metadata: { roles: ['watch'] }
-        // No token property
-      });
+      mockAuth.getAccessToken.mockResolvedValueOnce(null);
       
       await logic.connect('host', 1234, 'user', 'pass');
       
@@ -514,13 +873,21 @@ describe('useConnectionLogic', () => {
   });
 
   describe('connection error handling', () => {
-    it('should show error dialog on connection failure', async () => {
+    it('should roll back and show an error when Mumble connection fails', async () => {
       const testError = new Error('Connection refused');
+      mockUIStore.guacamoleFrame = { stop: jest.fn() };
+      mockDialogStore.connectDialog.isTestActive = true;
       mockConnectionStore.connect.mockRejectedValueOnce(testError);
       
       await logic.connect('host', 1234, 'user', 'pass');
       
       expect(mockDialogStore.showErrorDialog).toHaveBeenCalled();
+      expect(mockUIStore.guacamoleFrame.stop).toHaveBeenCalled();
+      expect(mockVoiceStore.endVoiceHandler).toHaveBeenCalled();
+      expect(mockConnectionStore.disconnect).toHaveBeenCalled();
+      expect(mockUserStore.thisUser).toBeNull();
+      expect(mockVoiceStore.isLoopbackMode).toBe(false);
+      expect(mockDialogStore.connectDialog.isTestActive).toBe(false);
     });
   });
 
@@ -536,49 +903,6 @@ describe('useConnectionLogic', () => {
     });
   });
 
-  describe('handleMicrophonePermission edge cases', () => {
-    it('should handle missing mediaDevices API', async () => {
-      const originalMediaDevices = navigator.mediaDevices;
-      Object.defineProperty(navigator, 'mediaDevices', {
-        value: undefined,
-        configurable: true
-      });
-      
-      // Should not throw when mediaDevices is undefined
-      await expect(logic.connect('host', 1234, 'user', 'pass')).resolves.not.toThrow();
-      
-      // Restore
-      Object.defineProperty(navigator, 'mediaDevices', {
-        value: originalMediaDevices,
-        configurable: true
-      });
-    });
-
-    it('should set micPermissionDenied on getUserMedia error', async () => {
-      const originalMediaDevices = navigator.mediaDevices;
-
-      Object.defineProperty(navigator, 'mediaDevices', {
-        value: {
-          getUserMedia: jest.fn().mockRejectedValue(new Error('Permission denied'))
-        },
-        configurable: true
-      });
-      
-      await logic.connect('host', 1234, 'user', 'pass');
-      
-      // Wait for async permission check
-      await new Promise(resolve => setTimeout(resolve, 10));
-      
-      // Should have set permission denied
-      expect(mockAudioStore.micPermissionDenied).toBe(true);
-      
-      // Restore
-      Object.defineProperty(navigator, 'mediaDevices', {
-        value: originalMediaDevices,
-        configurable: true
-      });
-    });
-  });
 
   describe('updateVoiceHandler callbacks', () => {
     it('should update talking state on voice start', () => {

--- a/__tests__/composables/useGuacamole.test.js
+++ b/__tests__/composables/useGuacamole.test.js
@@ -106,6 +106,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'complete',
       documentElement,
       querySelector: jest.fn(selector => selector === '#content' ? content : null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({ contentDocument });
 
@@ -118,6 +119,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({ contentDocument, token: null });
     const ready = waitForGuacamoleReady(iframe, { timeoutMs: 100 });
@@ -133,6 +135,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({
       contentDocument,
@@ -160,11 +163,13 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+      querySelectorAll: jest.fn(() => []),
     };
     const requestedDocument = {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({
       contentDocument: previousDocument,
@@ -192,6 +197,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(selector => selector.includes('.login-ui.error') ? errorElement : null),
+      querySelectorAll: jest.fn(() => [errorElement]),
     };
     const iframe = createIframe({ contentDocument });
 
@@ -210,6 +216,7 @@ describe('waitForGuacamoleReady', () => {
         if (selector.includes('.login-ui.error')) return hiddenError;
         return null;
       }),
+      querySelectorAll: jest.fn(() => [hiddenError]),
     };
     const iframe = createIframe({
       contentDocument,
@@ -221,11 +228,33 @@ describe('waitForGuacamoleReady', () => {
     await expect(waitForGuacamoleReady(iframe)).resolves.toBeUndefined();
   });
 
+  it('rejects when a later Guacamole error element is visible', async () => {
+    const content = {};
+    const hiddenError = {};
+    const visibleError = {};
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector === '#content' ? content : null),
+      querySelectorAll: jest.fn(() => [hiddenError, visibleError]),
+    };
+    const iframe = createIframe({
+      contentDocument,
+      getComputedStyle: jest.fn(element => element === hiddenError
+        ? { display: 'none', visibility: 'visible' }
+        : { display: 'block', visibility: 'visible' }),
+    });
+
+    await expect(waitForGuacamoleReady(iframe))
+      .rejects.toThrow('Remote desktop authentication failed');
+  });
+
   it('rejects a non-Guacamole response', async () => {
     const contentDocument = {
       readyState: 'complete',
       documentElement: { matches: jest.fn(() => false) },
       querySelector: jest.fn(() => null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({ contentDocument });
 
@@ -249,6 +278,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'loading',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(() => null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({ contentDocument, href: 'about:blank' });
     const ready = waitForGuacamoleReady(iframe, { signal: controller.signal });
@@ -267,6 +297,7 @@ describe('waitForGuacamoleReady', () => {
       readyState: 'loading',
       documentElement: { matches: jest.fn(() => true) },
       querySelector: jest.fn(() => null),
+      querySelectorAll: jest.fn(() => []),
     };
     const iframe = createIframe({ contentDocument, href: 'about:blank' });
     const ready = waitForGuacamoleReady(iframe, { timeoutMs: 100 });

--- a/__tests__/composables/useGuacamole.test.js
+++ b/__tests__/composables/useGuacamole.test.js
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  buildGuacamoleSource,
+  clearGuacamoleSession,
+  startGuacamoleFrame,
+  waitForGuacamoleReady,
+} from '../../app/composables/useGuacamole.js';
+
+function createIframe({
+  contentDocument,
+  href = 'https://example.test/guacamole/#/',
+  token = 'guacamole-token',
+  injector = true,
+  getComputedStyle = jest.fn(() => ({ display: 'block', visibility: 'visible' })),
+}) {
+  const listeners = new Map();
+  const authenticationService = {
+    getCurrentToken: jest.fn(() => token),
+  };
+  return {
+    contentDocument,
+    contentWindow: {
+      location: { href },
+      getComputedStyle,
+      angular: injector ? {
+        element: jest.fn(() => ({
+          injector: jest.fn(() => ({
+            get: jest.fn(() => authenticationService),
+          })),
+        })),
+      } : undefined,
+    },
+    addEventListener: jest.fn((event, handler) => listeners.set(event, handler)),
+    removeEventListener: jest.fn((event) => listeners.delete(event)),
+    dispatch(event) {
+      listeners.get(event)?.();
+    },
+  };
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('clearGuacamoleSession', () => {
+  it('removes the persisted Guacamole authentication token', () => {
+    const storage = { removeItem: jest.fn() };
+
+    clearGuacamoleSession(storage);
+
+    expect(storage.removeItem).toHaveBeenCalledWith('GUAC_AUTH_TOKEN');
+  });
+
+  it('does not fail when storage is unavailable', () => {
+    const storage = {
+      removeItem: jest.fn(() => { throw new Error('Storage unavailable'); }),
+    };
+
+    expect(() => clearGuacamoleSession(storage)).not.toThrow();
+  });
+});
+
+describe('buildGuacamoleSource', () => {
+  it('encodes every credential-derived fragment value', () => {
+    const source = buildGuacamoleSource('watch&password=attacker', 'p#ss&word', '7');
+
+    expect(source).toBe(
+      '/guacamole/?flexpairSession=7#/?username=watch%26password%3Dattacker&password=p%23ss%26word'
+    );
+  });
+});
+
+describe('startGuacamoleFrame', () => {
+  it('waits for the registered frame to become ready', async () => {
+    let markReady;
+    const ready = new Promise(resolve => { markReady = resolve; });
+    const frame = {
+      start: jest.fn(() => ready),
+      show: jest.fn(),
+    };
+
+    const start = startGuacamoleFrame('watcher', 'password', { guacamoleFrame: frame });
+
+    expect(frame.start).toHaveBeenCalledWith('watcher', 'password');
+    expect(frame.show).toHaveBeenCalled();
+    let settled = false;
+    start.finally(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    markReady();
+    await expect(start).resolves.toBeUndefined();
+  });
+
+  it('fails when the frame is not registered', async () => {
+    await expect(startGuacamoleFrame('watcher', 'password', { guacamoleFrame: null }))
+      .rejects.toThrow('Remote desktop is not ready');
+  });
+});
+
+describe('waitForGuacamoleReady', () => {
+  it('resolves only when Guacamole renders authenticated content', async () => {
+    const content = {};
+    const documentElement = { matches: jest.fn(() => true) };
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement,
+      querySelector: jest.fn(selector => selector === '#content' ? content : null),
+    };
+    const iframe = createIframe({ contentDocument });
+
+    await expect(waitForGuacamoleReady(iframe)).resolves.toBeUndefined();
+  });
+
+  it('does not accept raw Guacamole content before authentication completes', async () => {
+    jest.useFakeTimers();
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+    };
+    const iframe = createIframe({ contentDocument, token: null });
+    const ready = waitForGuacamoleReady(iframe, { timeoutMs: 100 });
+    const result = expect(ready).rejects.toThrow('Remote desktop timed out');
+
+    await jest.advanceTimersByTimeAsync(100);
+    await result;
+  });
+
+  it('ignores a previously ready iframe until the requested session loads', async () => {
+    jest.useFakeTimers();
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+    };
+    const iframe = createIframe({
+      contentDocument,
+      href: 'https://example.test/guacamole/?flexpairSession=1#/',
+    });
+    const ready = waitForGuacamoleReady(iframe, {
+      expectedSession: '2',
+      timeoutMs: 100,
+    });
+    let settled = false;
+    ready.then(() => { settled = true; });
+
+    await jest.advanceTimersByTimeAsync(50);
+    expect(settled).toBe(false);
+
+    iframe.contentWindow.location.href =
+      'https://example.test/guacamole/?flexpairSession=2#/';
+    iframe.contentDocument = { ...contentDocument };
+    iframe.dispatch('load');
+    await expect(ready).resolves.toBeUndefined();
+  });
+
+  it('ignores the previous document while the requested navigation is pending', async () => {
+    const previousDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+    };
+    const requestedDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector === '#content' ? {} : null),
+    };
+    const iframe = createIframe({
+      contentDocument: previousDocument,
+      href: 'https://example.test/guacamole/?flexpairSession=2#/',
+    });
+    const ready = waitForGuacamoleReady(iframe, { expectedSession: '2' });
+    let settled = false;
+    ready.then(() => { settled = true; });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    iframe.dispatch('load');
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    iframe.contentDocument = requestedDocument;
+    iframe.dispatch('load');
+    await expect(ready).resolves.toBeUndefined();
+  });
+
+  it('rejects an explicit Guacamole login error', async () => {
+    const errorElement = {};
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => selector.includes('.login-ui.error') ? errorElement : null),
+    };
+    const iframe = createIframe({ contentDocument });
+
+    await expect(waitForGuacamoleReady(iframe))
+      .rejects.toThrow('Remote desktop authentication failed');
+  });
+
+  it('ignores inactive Guacamole error markup', async () => {
+    const content = {};
+    const hiddenError = {};
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(selector => {
+        if (selector === '#content') return content;
+        if (selector.includes('.login-ui.error')) return hiddenError;
+        return null;
+      }),
+    };
+    const iframe = createIframe({
+      contentDocument,
+      getComputedStyle: jest.fn(element => element === hiddenError
+        ? { display: 'none', visibility: 'visible' }
+        : { display: 'block', visibility: 'visible' }),
+    });
+
+    await expect(waitForGuacamoleReady(iframe)).resolves.toBeUndefined();
+  });
+
+  it('rejects a non-Guacamole response', async () => {
+    const contentDocument = {
+      readyState: 'complete',
+      documentElement: { matches: jest.fn(() => false) },
+      querySelector: jest.fn(() => null),
+    };
+    const iframe = createIframe({ contentDocument });
+
+    await expect(waitForGuacamoleReady(iframe))
+      .rejects.toThrow('Remote desktop failed to load');
+  });
+
+  it('rejects when the iframe cannot be inspected as same-origin', async () => {
+    const iframe = createIframe({ contentDocument: null });
+    Object.defineProperty(iframe, 'contentDocument', {
+      get() { throw new DOMException('Blocked', 'SecurityError'); },
+    });
+
+    await expect(waitForGuacamoleReady(iframe))
+      .rejects.toThrow('Remote desktop failed to load');
+  });
+
+  it('rejects when startup is aborted', async () => {
+    const controller = new AbortController();
+    const contentDocument = {
+      readyState: 'loading',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(() => null),
+    };
+    const iframe = createIframe({ contentDocument, href: 'about:blank' });
+    const ready = waitForGuacamoleReady(iframe, { signal: controller.signal });
+    const result = expect(ready).rejects.toMatchObject({
+      code: 'GUACAMOLE_START_CANCELLED',
+    });
+
+    controller.abort();
+    await result;
+    expect(iframe.removeEventListener).toHaveBeenCalledWith('load', expect.any(Function));
+  });
+
+  it('times out while Guacamole remains unready', async () => {
+    jest.useFakeTimers();
+    const contentDocument = {
+      readyState: 'loading',
+      documentElement: { matches: jest.fn(() => true) },
+      querySelector: jest.fn(() => null),
+    };
+    const iframe = createIframe({ contentDocument, href: 'about:blank' });
+    const ready = waitForGuacamoleReady(iframe, { timeoutMs: 100 });
+    const result = expect(ready).rejects.toThrow('Remote desktop timed out');
+
+    await jest.advanceTimersByTimeAsync(100);
+    await result;
+  });
+});

--- a/__tests__/mumble-websocket.test.js
+++ b/__tests__/mumble-websocket.test.js
@@ -21,6 +21,12 @@ describe('mumble-websocket', () => {
       once: jest.fn(function(event, handler) {
         return this.on(event, handler);
       }),
+      removeListener: jest.fn(function(event, handler) {
+        if (this._handlers?.[event] === handler) {
+          delete this._handlers[event];
+        }
+        return this;
+      }),
       _trigger: function(event, ...args) {
         this._handlers?.[event]?.(...args);
       },
@@ -165,6 +171,19 @@ describe('mumble-websocket', () => {
       await expect(connect('ws://localhost:64738', {})).rejects.toThrow('Data stream connection failed');
     });
 
+    test('should destroy the websocket stream when connectDataStream throws', async () => {
+      const connectionError = new Error('Synchronous connection failure');
+      mockMumbleClient.connectDataStream.mockImplementationOnce(() => {
+        throw connectionError;
+      });
+      const connection = connect('ws://localhost:64738', {});
+
+      mockWs._trigger('connect');
+
+      await expect(connection).rejects.toThrow('Synchronous connection failure');
+      expect(mockWs.destroy).toHaveBeenCalled();
+    });
+
     test('should handle websocket error before connect', async () => {
       const networkError = new Error('Network unreachable');
       
@@ -188,6 +207,53 @@ describe('mumble-websocket', () => {
       await expect(connection).rejects.toMatchObject({ name: 'AbortError' });
       expect(mockWs.destroy).toHaveBeenCalled();
       expect(mockMumbleClient.connectDataStream).not.toHaveBeenCalled();
+    });
+
+    test('should destroy the websocket stream when aborted during the Mumble handshake', async () => {
+      let resolveHandshake;
+      mockMumbleClient.connectDataStream.mockReturnValueOnce(new Promise(resolve => {
+        resolveHandshake = resolve;
+      }));
+      const controller = new AbortController();
+      const connection = connect('ws://localhost:64738', {}, {
+        signal: controller.signal,
+      });
+      const rejection = expect(connection).rejects.toMatchObject({ name: 'AbortError' });
+
+      mockWs._trigger('connect');
+      await Promise.resolve();
+      controller.abort();
+      resolveHandshake({ connected: true });
+
+      await rejection;
+      expect(mockWs.destroy).toHaveBeenCalled();
+    });
+
+    test('should keep an established Mumble connection after its signal is aborted', async () => {
+      const controller = new AbortController();
+      const connection = connect('ws://localhost:64738', {}, {
+        signal: controller.signal,
+      });
+
+      mockWs._trigger('connect');
+      await expect(connection).resolves.toEqual({ connected: true });
+      mockWs.destroy.mockClear();
+
+      controller.abort();
+
+      expect(mockWs.destroy).not.toHaveBeenCalled();
+    });
+
+    test('should remove handshake listeners after the Mumble connection settles', async () => {
+      const connection = connect('ws://localhost:64738', {});
+
+      mockWs._trigger('connect');
+      await connection;
+
+      expect(mockWs.removeListener).toHaveBeenCalledWith('error', expect.any(Function));
+      expect(mockWs.removeListener).toHaveBeenCalledWith('connect', expect.any(Function));
+      expect(mockWs._handlers.error).toBeUndefined();
+      expect(mockWs._handlers.connect).toBeUndefined();
     });
 
     test('should handle concurrent connect calls independently', async () => {

--- a/__tests__/mumble-websocket.test.js
+++ b/__tests__/mumble-websocket.test.js
@@ -18,9 +18,13 @@ describe('mumble-websocket', () => {
         this._handlers[event] = handler;
         return this;
       }),
+      once: jest.fn(function(event, handler) {
+        return this.on(event, handler);
+      }),
       _trigger: function(event, ...args) {
         this._handlers?.[event]?.(...args);
-      }
+      },
+      destroy: jest.fn(),
     };
 
     mockWebsocketStream = jest.fn(() => mockWs);
@@ -170,6 +174,19 @@ describe('mumble-websocket', () => {
       await expect(connect('ws://localhost:64738', {})).rejects.toThrow('Network unreachable');
       
       // connectDataStream should not be called if websocket fails
+      expect(mockMumbleClient.connectDataStream).not.toHaveBeenCalled();
+    });
+
+    test('should destroy the pending websocket stream when aborted', async () => {
+      const controller = new AbortController();
+      const connection = connect('ws://localhost:64738', {}, {
+        signal: controller.signal,
+      });
+
+      controller.abort();
+
+      await expect(connection).rejects.toMatchObject({ name: 'AbortError' });
+      expect(mockWs.destroy).toHaveBeenCalled();
       expect(mockMumbleClient.connectDataStream).not.toHaveBeenCalled();
     });
 

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -285,6 +285,20 @@ describe('UI Freeze Regression (3.16.1)', () => {
     expect(frameContent).not.toContain('loading="lazy"');
   });
 
+  test('VERIFICATION: Guacamole iframe focus waits for readiness and ARIA update', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const framePath = path.join(process.cwd(), 'app', 'components', 'GuacamoleFrame.vue');
+    const frameContent = await fs.readFile(framePath, 'utf-8');
+
+    expect(frameContent).toContain('if (iframeRef.value && visible.value && !loading.value && !error.value)');
+    expect(frameContent).toContain('await nextTick();');
+    expect(frameContent).toContain('focusIframe();');
+    expect(frameContent).not.toContain('@load="handleLoad"');
+    expect(frameContent).not.toContain('function handleLoad()');
+  });
+
   test('VERIFICATION: leaving audio test uses the authenticated connection pipeline', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -274,6 +274,17 @@ describe('UI Freeze Regression (3.16.1)', () => {
     expect(appContent).toContain('uiStore.guacamoleFrame = guacamoleFrameRef.value');
   });
 
+  test('VERIFICATION: Guacamole iframe loads eagerly for immediate handoff', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const framePath = path.join(process.cwd(), 'app', 'components', 'GuacamoleFrame.vue');
+    const frameContent = await fs.readFile(framePath, 'utf-8');
+
+    expect(frameContent).toContain('loading="eager"');
+    expect(frameContent).not.toContain('loading="lazy"');
+  });
+
   test('VERIFICATION: leaving audio test uses the authenticated connection pipeline', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -285,6 +285,16 @@ describe('UI Freeze Regression (3.16.1)', () => {
     expect(frameContent).not.toContain('loading="lazy"');
   });
 
+  it('should remove an unavailable Guacamole iframe from the tab order', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const framePath = path.join(process.cwd(), 'app', 'components', 'GuacamoleFrame.vue');
+    const frameContent = await fs.readFile(framePath, 'utf-8');
+
+    expect(frameContent).toContain(':tabindex="loading || !!error ? -1 : 0"');
+  });
+
   test('VERIFICATION: Guacamole iframe focus waits for readiness and ARIA update', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -263,6 +263,139 @@ describe('UI Freeze Regression (3.16.1)', () => {
     console.log('✅ Auth initializes async at position:', authInitIndex);
   });
 
+  test('VERIFICATION: Guacamole frame is registered after App mounts', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const appPath = path.join(process.cwd(), 'app', 'components', 'App.vue');
+    const appContent = await fs.readFile(appPath, 'utf-8');
+
+    expect(appContent).toContain('ref="guacamoleFrameRef"');
+    expect(appContent).toContain('uiStore.guacamoleFrame = guacamoleFrameRef.value');
+  });
+
+  test('VERIFICATION: leaving audio test uses the authenticated connection pipeline', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const dialogPath = path.join(process.cwd(), 'app', 'components', 'ConnectDialog.vue');
+    const dialogContent = await fs.readFile(dialogPath, 'utf-8');
+
+    expect(dialogContent).not.toContain('getGuacamoleLogin');
+    expect(dialogContent).not.toContain('app_metadata?.roles');
+    expect(dialogContent).not.toContain('guacamoleFrame.start');
+    expect(dialogContent).toContain('await connectionLogic.connect(');
+  });
+
+  test('VERIFICATION: cancelling sample-rate warning cancels the stored attempt', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const dialogPath = path.join(process.cwd(), 'app', 'components', 'SampleRateWarningDialog.vue');
+    const dialogContent = await fs.readFile(dialogPath, 'utf-8');
+
+    expect(dialogContent).toContain('connectionLogic.cancelConnect(params);');
+  });
+
+  test('VERIFICATION: stale auth-close continuation cannot reopen connection UI', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const indexPath = path.join(process.cwd(), 'app', 'index.js');
+    const indexContent = await fs.readFile(indexPath, 'utf-8');
+    const authClose = indexContent.slice(
+      indexContent.indexOf('async function handleAuthClose'),
+      indexContent.indexOf('/**\n * Handle authentication error event')
+    );
+
+    expect(indexContent).toContain('let authSessionGeneration = 0;');
+    expect(authClose).toContain('const sessionGeneration = authSessionGeneration;');
+    expect(authClose).toContain('if (sessionGeneration !== authSessionGeneration) return;');
+    expect(authClose).toContain("await auth.openAuth('login');");
+    expect(authClose).toContain("console.warn('[Auth] Failed to read session after closing authentication:'");
+  });
+
+  test('VERIFICATION: auth reset unloads the Guacamole session', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const framePath = path.join(process.cwd(), 'app', 'components', 'GuacamoleFrame.vue');
+    const indexPath = path.join(process.cwd(), 'app', 'index.js');
+    const [frameContent, indexContent] = await Promise.all([
+      fs.readFile(framePath, 'utf-8'),
+      fs.readFile(indexPath, 'utf-8'),
+    ]);
+
+    expect(frameContent).toContain('function stop()');
+    expect(frameContent).toContain('guacSource.value = null;');
+    const authReset = indexContent.slice(
+      indexContent.indexOf('function resetAuthenticatedConnection'),
+      indexContent.indexOf('function handleAuthLogin')
+    );
+
+    expect(authReset).toContain('uiStore.guacamoleFrame?.stop?.();');
+    expect(authReset).toContain('audioStore.stopBeep();');
+    expect(authReset).toContain('dialogStore.connectDialog.isTestActive = false;');
+    expect(indexContent).not.toContain('uiStore.guacamoleFrame?.hide?.();');
+  });
+
+  test('VERIFICATION: toolbar waits for logout before reloading', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const toolbarPath = path.join(process.cwd(), 'app', 'components', 'Toolbar.vue');
+    const toolbarContent = await fs.readFile(toolbarPath, 'utf-8');
+    const logoutHandler = toolbarContent.slice(
+      toolbarContent.indexOf('const handleLogoutClick'),
+      toolbarContent.indexOf('</script>')
+    );
+
+    expect(logoutHandler).toContain('await auth.logout();');
+    expect(logoutHandler.indexOf('await auth.logout();'))
+      .toBeLessThan(logoutHandler.indexOf('location.reload();'));
+  });
+
+  test('VERIFICATION: a replacement login tears down the previous connection', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const indexPath = path.join(process.cwd(), 'app', 'index.js');
+    const indexContent = await fs.readFile(indexPath, 'utf-8');
+    const loginHandler = indexContent.slice(
+      indexContent.indexOf('function handleAuthLogin'),
+      indexContent.indexOf('function handleAuthLogout')
+    );
+
+    expect(loginHandler).toContain('resetAuthenticatedConnection();');
+  });
+
+  test('VERIFICATION: replacement login preserves the configured connection target', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const indexPath = path.join(process.cwd(), 'app', 'index.js');
+    const indexContent = await fs.readFile(indexPath, 'utf-8');
+    const authReset = indexContent.slice(
+      indexContent.indexOf('function resetAuthenticatedConnection'),
+      indexContent.indexOf('function handleAuthLogin')
+    );
+    const loginHandler = indexContent.slice(
+      indexContent.indexOf('function handleAuthLogin'),
+      indexContent.indexOf('function handleAuthLogout')
+    );
+    const logoutHandler = indexContent.slice(
+      indexContent.indexOf('function handleAuthLogout'),
+      indexContent.indexOf('function handleAuthClose')
+    );
+
+    expect(authReset).not.toContain('dialogStore.resetAll();');
+    expect(loginHandler).not.toContain('dialogStore.resetAll();');
+    expect(loginHandler).toContain('dialogStore.resetErrorDialog();');
+    expect(loginHandler).toContain('dialogStore.resetInfoDialog();');
+    expect(loginHandler).toContain('dialogStore.resetSampleRateDialog();');
+    expect(logoutHandler).toContain('dialogStore.resetAll();');
+  });
+
   /**
    * INTEGRATION TEST:
    * Verify AppState.js has been completely removed (migration complete)

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -364,28 +364,29 @@ describe('UI Freeze Regression (3.16.1)', () => {
     expect(indexContent).not.toContain('uiStore.guacamoleFrame?.hide?.();');
   });
 
-  test('VERIFICATION: toolbar clears local runtime before bounded provider logout', async () => {
+  test('VERIFICATION: shared logout clears local runtime before bounded provider logout', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
-    const toolbarPath = path.resolve(process.cwd(), 'app/components/Toolbar.vue');
-    const toolbarContent = await fs.readFile(toolbarPath, 'utf8');
-    const logoutHandler = toolbarContent.slice(
-      toolbarContent.indexOf('const handleLogoutClick'),
-      toolbarContent.indexOf('</script>')
-    );
+    const [logoutContent, toolbarContent, dialogContent] = await Promise.all([
+      fs.readFile(path.resolve(process.cwd(), 'app/composables/useAuthLogout.js'), 'utf8'),
+      fs.readFile(path.resolve(process.cwd(), 'app/components/Toolbar.vue'), 'utf8'),
+      fs.readFile(path.resolve(process.cwd(), 'app/components/ConnectDialog.vue'), 'utf8'),
+    ]);
 
-    const voiceResetIndex = logoutHandler.indexOf('voiceStore.reset();');
-    const disconnectIndex = logoutHandler.indexOf('connectionStore.disconnect();');
-    const providerLogoutIndex = logoutHandler.indexOf('auth.logout().catch');
-    const reloadIndex = logoutHandler.indexOf('location.reload();');
+    const clearCredentialsIndex = logoutContent.indexOf('clearCredentials();');
+    const resetSessionIndex = logoutContent.indexOf('resetSessionState(dependencies);');
+    const providerLogoutIndex = logoutContent.indexOf('dependencies.auth.logout()');
+    const reloadIndex = logoutContent.indexOf('reload();');
 
-    expect(voiceResetIndex).toBeGreaterThanOrEqual(0);
-    expect(disconnectIndex).toBeGreaterThan(voiceResetIndex);
-    expect(providerLogoutIndex).toBeGreaterThan(disconnectIndex);
+    expect(clearCredentialsIndex).toBeGreaterThanOrEqual(0);
+    expect(resetSessionIndex).toBeGreaterThan(clearCredentialsIndex);
+    expect(providerLogoutIndex).toBeGreaterThan(resetSessionIndex);
     expect(reloadIndex).toBeGreaterThan(providerLogoutIndex);
-    expect(logoutHandler).toContain('Promise.race');
-    expect(logoutHandler).toContain('setTimeout(resolve, 1500)');
+    expect(logoutContent).toContain('Promise.race');
+    expect(logoutContent).toContain('setTimeout(resolve, LOGOUT_TIMEOUT_MS)');
+    expect(toolbarContent).toContain('logoutSession({');
+    expect(dialogContent).toContain('logoutSession({');
   });
 
   test('VERIFICATION: a replacement login tears down the previous connection', async () => {

--- a/__tests__/regression/ui-initialization-blocking.test.js
+++ b/__tests__/regression/ui-initialization-blocking.test.js
@@ -364,20 +364,28 @@ describe('UI Freeze Regression (3.16.1)', () => {
     expect(indexContent).not.toContain('uiStore.guacamoleFrame?.hide?.();');
   });
 
-  test('VERIFICATION: toolbar waits for logout before reloading', async () => {
+  test('VERIFICATION: toolbar clears local runtime before bounded provider logout', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
-    const toolbarPath = path.join(process.cwd(), 'app', 'components', 'Toolbar.vue');
-    const toolbarContent = await fs.readFile(toolbarPath, 'utf-8');
+    const toolbarPath = path.resolve(process.cwd(), 'app/components/Toolbar.vue');
+    const toolbarContent = await fs.readFile(toolbarPath, 'utf8');
     const logoutHandler = toolbarContent.slice(
       toolbarContent.indexOf('const handleLogoutClick'),
       toolbarContent.indexOf('</script>')
     );
 
-    expect(logoutHandler).toContain('await auth.logout();');
-    expect(logoutHandler.indexOf('await auth.logout();'))
-      .toBeLessThan(logoutHandler.indexOf('location.reload();'));
+    const voiceResetIndex = logoutHandler.indexOf('voiceStore.reset();');
+    const disconnectIndex = logoutHandler.indexOf('connectionStore.disconnect();');
+    const providerLogoutIndex = logoutHandler.indexOf('auth.logout().catch');
+    const reloadIndex = logoutHandler.indexOf('location.reload();');
+
+    expect(voiceResetIndex).toBeGreaterThanOrEqual(0);
+    expect(disconnectIndex).toBeGreaterThan(voiceResetIndex);
+    expect(providerLogoutIndex).toBeGreaterThan(disconnectIndex);
+    expect(reloadIndex).toBeGreaterThan(providerLogoutIndex);
+    expect(logoutHandler).toContain('Promise.race');
+    expect(logoutHandler).toContain('setTimeout(resolve, 1500)');
   });
 
   test('VERIFICATION: a replacement login tears down the previous connection', async () => {

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -48,7 +48,8 @@ const mockAudioContextManager = {
   audioContext: null,
   onReady: jest.fn(),
   onSuspend: jest.fn(),
-  onResume: jest.fn()
+  onResume: jest.fn(),
+  resumeAudioContext: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockGetCurrentMixer = jest.fn(() => null);
@@ -123,6 +124,7 @@ describe('audioStore', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAudioContextManager.resumeAudioContext.mockClear();
     mockEnsureAudioContext.mockResolvedValue({
       state: 'running',
       resume: jest.fn().mockResolvedValue(undefined),
@@ -209,15 +211,17 @@ describe('audioStore', () => {
 
       await store.resumeAudioContext();
 
-      expect(mockResume).toHaveBeenCalled();
+      expect(mockAudioContextManager.resumeAudioContext).toHaveBeenCalled();
+      expect(mockResume).not.toHaveBeenCalled();
     });
 
-    test('should not call resume on running context', async () => {
+    test('should route running context through the manager', async () => {
       const mockResume = jest.fn();
       store.audioContext.value = { state: 'running', resume: mockResume };
 
       await store.resumeAudioContext();
 
+      expect(mockAudioContextManager.resumeAudioContext).toHaveBeenCalled();
       expect(mockResume).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -72,10 +72,10 @@ jest.unstable_mockModule('../../app/utils/debug-utils.js', () => ({
 
 // Mock promise-cache-utils
 jest.unstable_mockModule('../../app/utils/promise-cache-utils.js', () => ({
-  createCachedInitWithCheck: (check, init) => async () => {
+  createCachedInitWithCheck: (check, init) => async (...args) => {
     const existing = check();
     if (existing) return existing;
-    return init();
+    return init(...args);
   }
 }));
 
@@ -85,7 +85,9 @@ function createMockAudioContext(state = 'running') {
   const oscillator = {
     frequency: { setValueAtTime: jest.fn() },
     connect: jest.fn(),
+    disconnect: jest.fn(),
     start: jest.fn(),
+    stop: jest.fn(),
     type: ''
   };
   const gainNodes = [];
@@ -108,6 +110,7 @@ function createMockAudioContext(state = 'running') {
           exponentialRampToValueAtTime: jest.fn()
         },
         connect: jest.fn(),
+        disconnect: jest.fn(),
         context: audioContext
       };
       gainNodes.push(node);
@@ -407,6 +410,25 @@ describe('audioStore', () => {
   });
 
   describe('initializePersistentBeeper edge cases', () => {
+    test('recreates the beeper when the mixer changes', async () => {
+      const firstMixer = {};
+      const secondMixer = {};
+      const audioContext = createMockAudioContext();
+      mockGetCurrentMixer.mockReturnValue(firstMixer);
+      globalThis.audioContextManager = {
+        getAudioContext: jest.fn().mockResolvedValue(audioContext)
+      };
+
+      const firstBeeper = await store.initializePersistentBeeper();
+      mockGetCurrentMixer.mockReturnValue(secondMixer);
+      const secondBeeper = await store.initializePersistentBeeper();
+
+      expect(secondBeeper).not.toBe(firstBeeper);
+      expect(firstBeeper.oscillator.stop).toHaveBeenCalledTimes(1);
+      expect(firstBeeper.gain.disconnect).toHaveBeenCalledTimes(1);
+      expect(secondBeeper.gain.connect).toHaveBeenCalledWith(secondMixer);
+    });
+
     test('should return null when AudioContext is closed', async () => {
       mockGetCurrentMixer.mockReturnValue({});
       // Mock global audioContextManager

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -328,13 +328,13 @@ describe('audioStore', () => {
       expect(result).toBe(mockContext);
     });
 
-    test('should reject when managed and legacy initialization both fail', async () => {
+    test('should reject when managed initialization fails', async () => {
       mockEnsureAudioContext.mockRejectedValueOnce(new Error('Managed initialization failed'));
       delete globalThis.AudioContext;
       delete globalThis.webkitAudioContext;
 
       await expect(store.initializeAudioContext())
-        .rejects.toThrow('AudioContext is not supported in this browser');
+        .rejects.toThrow('Managed initialization failed');
       expect(store.audioContext.value).toBeNull();
     });
   });

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -508,6 +508,32 @@ describe('audioStore', () => {
       expect(store.isBeeping.value).toBe(true);
     });
 
+    test('does not start a beeper that was reset while the context resumed', async () => {
+      let resolveResume;
+      const audioContext = createMockAudioContext('suspended');
+      audioContext.resume.mockImplementation(() => new Promise(resolve => {
+        resolveResume = () => {
+          audioContext.state = 'running';
+          resolve();
+        };
+      }));
+      mockGetCurrentMixer.mockReturnValue({});
+      globalThis.audioContextManager = {
+        getAudioContext: jest.fn().mockResolvedValue(audioContext)
+      };
+
+      await store.initializePersistentBeeper();
+      const start = store.startBeep();
+      await Promise.resolve();
+      store.resetBeeper();
+      resolveResume();
+      await start;
+
+      expect(audioContext.gainNodes[0].gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+      expect(audioContext.gainNodes[1].gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+      expect(store.isBeeping.value).toBe(false);
+    });
+
     test('should stop initialized beeper with fade out', async () => {
       const audioContext = createMockAudioContext();
       mockGetCurrentMixer.mockReturnValue({});

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -52,14 +52,11 @@ const mockAudioContextManager = {
 };
 
 const mockGetCurrentMixer = jest.fn(() => null);
+const mockEnsureAudioContext = jest.fn();
 
 jest.unstable_mockModule('../../app/audio/audio-context-manager.js', () => ({
   default: mockAudioContextManager,
-  ensureAudioContext: jest.fn().mockResolvedValue({
-    state: 'running',
-    resume: jest.fn().mockResolvedValue(undefined),
-    audioWorklet: { addModule: jest.fn().mockResolvedValue(undefined) }
-  })
+  ensureAudioContext: mockEnsureAudioContext
 }));
 
 // Mock voice module
@@ -126,6 +123,11 @@ describe('audioStore', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEnsureAudioContext.mockResolvedValue({
+      state: 'running',
+      resume: jest.fn().mockResolvedValue(undefined),
+      audioWorklet: { addModule: jest.fn().mockResolvedValue(undefined) }
+    });
     mockGetCurrentMixer.mockReturnValue(null);
     delete globalThis.audioContextManager;
     store = useAudioStore();
@@ -320,6 +322,16 @@ describe('audioStore', () => {
       const result = await store.initializeAudioContext();
 
       expect(result).toBe(mockContext);
+    });
+
+    test('should reject when managed and legacy initialization both fail', async () => {
+      mockEnsureAudioContext.mockRejectedValueOnce(new Error('Managed initialization failed'));
+      delete globalThis.AudioContext;
+      delete globalThis.webkitAudioContext;
+
+      await expect(store.initializeAudioContext())
+        .rejects.toThrow('AudioContext is not supported in this browser');
+      expect(store.audioContext.value).toBeNull();
     });
   });
 

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -523,6 +523,35 @@ describe('audioStore', () => {
       expect(audioContext.gainNodes[1].gain.exponentialRampToValueAtTime).toHaveBeenCalledWith(0.001, 11.3);
       expect(store.isBeeping.value).toBe(false);
     });
+
+    test('discards an initialization that completes after the mixer changes', async () => {
+      let resolveAudioContext;
+      const firstContext = new Promise(resolve => {
+        resolveAudioContext = resolve;
+      });
+      const staleAudioContext = createMockAudioContext();
+      const currentAudioContext = createMockAudioContext();
+      const firstMixer = {};
+      const secondMixer = {};
+      mockGetCurrentMixer.mockReturnValueOnce(firstMixer).mockReturnValue(secondMixer);
+      globalThis.audioContextManager = {
+        getAudioContext: jest.fn()
+          .mockReturnValueOnce(firstContext)
+          .mockResolvedValueOnce(currentAudioContext)
+      };
+
+      const staleInitialization = store.initializePersistentBeeper();
+      const currentInitialization = store.initializePersistentBeeper();
+      resolveAudioContext(staleAudioContext);
+
+      await staleInitialization;
+      await currentInitialization;
+
+      expect(staleAudioContext.oscillator.start).not.toHaveBeenCalled();
+      expect(currentAudioContext.oscillator.start).toHaveBeenCalledTimes(1);
+      expect(currentAudioContext.gainNodes[0].connect).toHaveBeenCalledWith(secondMixer);
+      expect(store.beeperReady.value).toBe(true);
+    });
   });
 
   describe('stopBeep with playing beeper', () => {

--- a/__tests__/stores/connectionStore-pinia.test.js
+++ b/__tests__/stores/connectionStore-pinia.test.js
@@ -269,6 +269,20 @@ describe('connectionStore', () => {
       await expect(secondConnection).resolves.toBe(mockClient);
       expect(WorkerBasedMumbleConnector).toHaveBeenCalledTimes(1);
     });
+
+    it('should retry connector initialization after a transient failure', async () => {
+      const { default: WorkerBasedMumbleConnector } = await import('../../app/worker-client.js');
+      WorkerBasedMumbleConnector.mockImplementationOnce(() => {
+        throw new Error('Worker startup failed');
+      });
+
+      await expect(store.connect('first', 64738, 'first', 'pass'))
+        .rejects.toThrow('Worker startup failed');
+      await expect(store.connect('second', 64738, 'second', 'pass'))
+        .resolves.toBe(mockClient);
+
+      expect(WorkerBasedMumbleConnector).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('disconnect()', () => {

--- a/__tests__/stores/connectionStore-pinia.test.js
+++ b/__tests__/stores/connectionStore-pinia.test.js
@@ -256,6 +256,19 @@ describe('connectionStore', () => {
       expect(store.client.value).toBe(secondClient);
       expect(store.remoteHost.value).toBe('second');
     });
+
+    it('should share connector initialization between concurrent first connections', async () => {
+      const { default: WorkerBasedMumbleConnector } = await import('../../app/worker-client.js');
+
+      const firstConnection = store.connect('first', 64738, 'first', 'pass');
+      const secondConnection = store.connect('second', 64738, 'second', 'pass');
+
+      await expect(firstConnection).rejects.toMatchObject({
+        code: 'CONNECTION_ATTEMPT_SUPERSEDED',
+      });
+      await expect(secondConnection).resolves.toBe(mockClient);
+      expect(WorkerBasedMumbleConnector).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('disconnect()', () => {

--- a/__tests__/stores/connectionStore-pinia.test.js
+++ b/__tests__/stores/connectionStore-pinia.test.js
@@ -23,6 +23,7 @@ jest.unstable_mockModule('vue', () => ({
     get value() { return fn(); },
     __v_isRef: true 
   }),
+  toRaw: jest.fn((value) => value.__raw ?? value),
 }));
 
 // Mock Pinia
@@ -147,6 +148,19 @@ describe('connectionStore', () => {
       expect(mockConnector.connect).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ tokens: [] }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it('should unwrap reactive token arrays before passing them to the worker connector', async () => {
+      const rawTokens = ['tok1', 'tok2'];
+      const reactiveTokens = { __raw: rawTokens };
+
+      await store.connect('host', 64738, 'user', 'pass', reactiveTokens);
+
+      expect(mockConnector.connect).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ tokens: rawTokens }),
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });

--- a/__tests__/stores/connectionStore-pinia.test.js
+++ b/__tests__/stores/connectionStore-pinia.test.js
@@ -189,6 +189,48 @@ describe('connectionStore', () => {
       
       expect(store.isConnected.value).toBe(true);
     });
+
+    it('should disconnect a client that resolves after the attempt was cancelled', async () => {
+      let resolveConnection;
+      const staleClient = { ...mockClient, disconnect: jest.fn() };
+      mockConnector.connect.mockReturnValueOnce(new Promise(resolve => {
+        resolveConnection = resolve;
+      }));
+
+      const connection = store.connect('host', 64738, 'user', 'pass');
+      store.disconnect();
+      resolveConnection(staleClient);
+
+      await expect(connection).rejects.toMatchObject({
+        code: 'CONNECTION_ATTEMPT_SUPERSEDED',
+      });
+      expect(staleClient.disconnect).toHaveBeenCalled();
+      expect(store.client.value).toBeNull();
+    });
+
+    it('should retain only the newest concurrently resolved client', async () => {
+      let resolveFirst;
+      let resolveSecond;
+      const firstClient = { ...mockClient, disconnect: jest.fn() };
+      const secondClient = { ...mockClient, disconnect: jest.fn() };
+      mockConnector.connect
+        .mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve; }))
+        .mockReturnValueOnce(new Promise(resolve => { resolveSecond = resolve; }));
+
+      const firstConnection = store.connect('first', 64738, 'first', 'pass');
+      const secondConnection = store.connect('second', 64738, 'second', 'pass');
+      resolveSecond(secondClient);
+      await expect(secondConnection).resolves.toBe(secondClient);
+      resolveFirst(firstClient);
+      await expect(firstConnection).rejects.toMatchObject({
+        code: 'CONNECTION_ATTEMPT_SUPERSEDED',
+      });
+
+      expect(firstClient.disconnect).toHaveBeenCalled();
+      expect(secondClient.disconnect).not.toHaveBeenCalled();
+      expect(store.client.value).toBe(secondClient);
+      expect(store.remoteHost.value).toBe('second');
+    });
   });
 
   describe('disconnect()', () => {

--- a/__tests__/stores/connectionStore-pinia.test.js
+++ b/__tests__/stores/connectionStore-pinia.test.js
@@ -136,7 +136,8 @@ describe('connectionStore', () => {
           username: 'myuser',
           password: 'mypass',
           tokens: ['tok1', 'tok2'],
-        })
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });
 
@@ -145,7 +146,8 @@ describe('connectionStore', () => {
 
       expect(mockConnector.connect).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ tokens: [] })
+        expect.objectContaining({ tokens: [] }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });
 
@@ -206,6 +208,29 @@ describe('connectionStore', () => {
       });
       expect(staleClient.disconnect).toHaveBeenCalled();
       expect(store.client.value).toBeNull();
+    });
+
+    it('should abort a pending worker connection when disconnected', async () => {
+      let capturedSignal;
+      mockConnector.connect.mockImplementationOnce((host, args, { signal }) => (
+        new Promise((resolve, reject) => {
+          capturedSignal = signal;
+          signal.addEventListener('abort', () => {
+            reject(Object.assign(new Error('Connection aborted'), { name: 'AbortError' }));
+          }, { once: true });
+        })
+      ));
+
+      const connection = store.connect('host', 64738, 'user', 'pass');
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(capturedSignal).toBeDefined();
+
+      store.disconnect();
+
+      expect(capturedSignal.aborted).toBe(true);
+      await expect(connection).rejects.toMatchObject({
+        code: 'CONNECTION_ATTEMPT_SUPERSEDED',
+      });
     });
 
     it('should retain only the newest concurrently resolved client', async () => {

--- a/__tests__/stores/dialog-stores.test.js
+++ b/__tests__/stores/dialog-stores.test.js
@@ -113,14 +113,14 @@ describe('useDialogStore', () => {
       expect(store.errorDialog.reason).toBe('');
     });
 
-    test('showErrorDialog() handles error without type (defaults to 0)', () => {
+    test('showErrorDialog() handles error without type as a generic setup failure', () => {
       const store = useDialogStore();
       
       const error = { reason: 'Some error' };
       store.showErrorDialog(error);
       
       expect(store.errorDialog.visible).toBe(true);
-      expect(store.errorDialog.type).toBe(0);
+      expect(store.errorDialog.type).toBe('generic');
       expect(store.errorDialog.reason).toBe('Some error');
     });
 

--- a/__tests__/stores/userStore.test.js
+++ b/__tests__/stores/userStore.test.js
@@ -401,7 +401,7 @@ describe('useUserStore registerUser', () => {
       selfMute: false,
       selfDeaf: false,
       on: jest.fn(),
-      off: jest.fn()
+      removeListener: jest.fn()
     };
   });
 
@@ -430,7 +430,7 @@ describe('useUserStore registerUser', () => {
     
     userStore.registerUser(mockUser);
     
-    expect(mockUser.off).toHaveBeenCalledWith('server-state-sync', oldSyncFn);
+    expect(mockUser.removeListener).toHaveBeenCalledWith('server-state-sync', oldSyncFn);
     expect(mockUser.__ui.old).toBeUndefined();
   });
 
@@ -523,9 +523,9 @@ describe('useUserStore registerUser', () => {
 
     userStore.reset();
 
-    expect(mockUser.off).toHaveBeenCalledWith('server-state-sync', listeners['server-state-sync']);
-    expect(mockUser.off).toHaveBeenCalledWith('update', listeners.update);
-    expect(mockUser.off).toHaveBeenCalledWith('voice', listeners.voice);
+    expect(mockUser.removeListener).toHaveBeenCalledWith('server-state-sync', listeners['server-state-sync']);
+    expect(mockUser.removeListener).toHaveBeenCalledWith('update', listeners.update);
+    expect(mockUser.removeListener).toHaveBeenCalledWith('voice', listeners.voice);
   });
 });
 

--- a/__tests__/stores/userStore.test.js
+++ b/__tests__/stores/userStore.test.js
@@ -86,8 +86,23 @@ jest.unstable_mockModule('../../app/composables/useLocalStorage.js', async () =>
 });
 
 // Mock other dependencies
+let resolveNodeInitialization;
 jest.unstable_mockModule('../../app/audio/buffer-queue-node', () => ({
   default: class MockBufferQueueNode {
+    static instances = [];
+
+    constructor() {
+      this.initialize = jest.fn(() => (
+        resolveNodeInitialization
+          ? new Promise(resolve => { resolveNodeInitialization = resolve; })
+          : Promise.resolve()
+      ));
+      this.connect = jest.fn();
+      this.write = jest.fn();
+      this.end = jest.fn();
+      MockBufferQueueNode.instances.push(this);
+    }
+
     setJitterBufferSize() {
       // Mock implementation - no operation needed for tests
     }
@@ -375,6 +390,8 @@ describe('useUserStore registerUser', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia());
+    resolveNodeInitialization = null;
+    mockAudioState.getAudioContext.mockClear();
     userStore = useUserStore();
     
     mockUser = {
@@ -409,7 +426,7 @@ describe('useUserStore registerUser', () => {
   test('should clean up previous UI wrapper if exists', () => {
     const oldSyncFn = jest.fn();
     mockUser.__ui = { old: true };
-    mockUser.__syncServerState = oldSyncFn;
+    mockUser.__uiListeners = { 'server-state-sync': oldSyncFn };
     
     userStore.registerUser(mockUser);
     
@@ -460,6 +477,55 @@ describe('useUserStore registerUser', () => {
     
     expect(userStore.selfMute).toBe(true);
     expect(userStore.selfDeaf).toBe(true);
+  });
+
+  test('should ignore queued callbacks after registration ownership expires', async () => {
+    let isCurrent = true;
+    userStore.registerUser(mockUser, () => isCurrent);
+    const syncHandler = mockUser.on.mock.calls.find(c => c[0] === 'server-state-sync')[1];
+    const updateHandler = mockUser.on.mock.calls.find(c => c[0] === 'update')[1];
+    const voiceHandler = mockUser.on.mock.calls.find(c => c[0] === 'voice')[1];
+    const initialSelfMute = userStore.selfMute;
+    const initialSelfDeaf = userStore.selfDeaf;
+
+    isCurrent = false;
+    syncHandler({ selfMute: true, selfDeaf: true });
+    updateHandler(null, { selfMute: true, selfDeaf: true });
+    await voiceHandler({ on: jest.fn() });
+
+    expect(userStore.selfMute).toBe(initialSelfMute);
+    expect(userStore.selfDeaf).toBe(initialSelfDeaf);
+    expect(mockUser.__ui.selfMute.value).toBe(false);
+    expect(mockUser.__ui.selfDeaf.value).toBe(false);
+    expect(mockAudioState.getAudioContext).not.toHaveBeenCalled();
+  });
+
+  test('should dispose a voice node when ownership expires during initialization', async () => {
+    let isCurrent = true;
+    resolveNodeInitialization = true;
+    userStore.registerUser(mockUser, () => isCurrent);
+    const voiceHandler = mockUser.on.mock.calls.find(c => c[0] === 'voice')[1];
+
+    const pendingVoice = voiceHandler({ on: jest.fn() });
+    await Promise.resolve();
+    isCurrent = false;
+    resolveNodeInitialization();
+    await pendingVoice;
+
+    const { default: MockBufferQueueNode } = await import('../../app/audio/buffer-queue-node');
+    expect(MockBufferQueueNode.instances.at(-1).end).toHaveBeenCalledTimes(1);
+    expect(mockAudioState.getAudioContext).toHaveBeenCalledTimes(1);
+  });
+
+  test('reset should detach registered user listeners', () => {
+    userStore.registerUser(mockUser);
+    const listeners = Object.fromEntries(mockUser.on.mock.calls);
+
+    userStore.reset();
+
+    expect(mockUser.off).toHaveBeenCalledWith('server-state-sync', listeners['server-state-sync']);
+    expect(mockUser.off).toHaveBeenCalledWith('update', listeners.update);
+    expect(mockUser.off).toHaveBeenCalledWith('voice', listeners.voice);
   });
 });
 

--- a/__tests__/stores/userStore.test.js
+++ b/__tests__/stores/userStore.test.js
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 
+const watcherCleanups = [];
+
 // Mock Vue with working reactivity for this test
 jest.unstable_mockModule('vue', () => {
   const listeners = new Map();
@@ -73,7 +75,7 @@ jest.unstable_mockModule('vue', () => {
       const { get, set } = factory(() => {}, () => {});
       return { get value() { return get(); }, set value(v) { set(v); }, __v_isRef: true };
     },
-    onWatcherCleanup: () => {},
+    onWatcherCleanup: (callback) => watcherCleanups.push(callback),
   };
 });
 
@@ -182,7 +184,7 @@ function createMockClient() {
   return {
     dataStats: { mean: 200, variance: 25, n: 100 }, // High latency (200ms)
     on: jest.fn(),
-    off: jest.fn()
+    removeListener: jest.fn()
   };
 }
 
@@ -204,6 +206,7 @@ describe('useUserStore Jitter Buffer Calculation', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia());
+    watcherCleanups.length = 0;
     
         // Reset settings store mock
     mockSettingsStore.jitterBufferSize = 3;
@@ -223,6 +226,15 @@ describe('useUserStore Jitter Buffer Calculation', () => {
     };
 
     userStore = useUserStore();
+  });
+
+  test('should detach the jitter listener through the supported EventEmitter API', () => {
+    const { thisUser } = storeToRefs(userStore);
+    thisUser.value = mockUIUser;
+
+    watcherCleanups.at(-1)();
+
+    expect(mockClient.removeListener).toHaveBeenCalledWith('dataPing', expect.any(Function));
   });
 
 

--- a/__tests__/stores/voiceStore.test.js
+++ b/__tests__/stores/voiceStore.test.js
@@ -46,6 +46,7 @@ jest.unstable_mockModule('pinia', () => ({
 // Mock audioStore
 const mockAudioStore = {
   activateAudioLock: jest.fn(),
+  resetBeeper: jest.fn(),
   resumeAudioContext: jest.fn().mockResolvedValue(undefined),
   loadAudioWorkletModule: jest.fn().mockResolvedValue(undefined),
   initializePersistentBeeper: jest.fn()

--- a/__tests__/stores/voiceStore.test.js
+++ b/__tests__/stores/voiceStore.test.js
@@ -80,12 +80,15 @@ const mockVoiceHandler = {
   write: jest.fn(),
   on: jest.fn()
 };
+const mockStopVoiceInput = jest.fn();
 
 jest.unstable_mockModule('../../app/audio/voice.js', () => ({
   ContinuousVoiceHandler: jest.fn(() => mockVoiceHandler),
   PushToTalkVoiceHandler: jest.fn(() => mockVoiceHandler),
-  initVoice: jest.fn(),
-  onAudioMixerReady: jest.fn()
+  initVoice: jest.fn((_onData, _onError, onReady) => {
+    onReady?.({});
+    return mockStopVoiceInput;
+  })
 }));
 
 // Mock localize
@@ -99,7 +102,7 @@ jest.unstable_mockModule('../../app/utils/debug-utils.js', () => ({
 }));
 
 const { useVoiceStore } = await import('../../app/stores/voiceStore.js');
-const { ContinuousVoiceHandler, PushToTalkVoiceHandler, initVoice, onAudioMixerReady } = 
+const { ContinuousVoiceHandler, PushToTalkVoiceHandler, initVoice } =
   await import('../../app/audio/voice.js');
 
 describe('voiceStore', () => {
@@ -111,6 +114,11 @@ describe('voiceStore', () => {
     mockVoiceHandler.setMute.mockClear();
     mockVoiceHandler.write.mockClear();
     mockVoiceHandler.on.mockClear();
+    mockStopVoiceInput.mockClear();
+    initVoice.mockImplementation((_onData, _onError, onReady) => {
+      onReady?.({});
+      return mockStopVoiceInput;
+    });
     store = useVoiceStore();
   });
 
@@ -139,23 +147,21 @@ describe('voiceStore', () => {
 
       store.initVoiceInput(onData, onError);
 
-      expect(initVoice).toHaveBeenCalledWith(onData, onError);
+      expect(initVoice).toHaveBeenCalledWith(
+        onData,
+        expect.any(Function),
+        expect.any(Function)
+      );
     });
 
-    test('should register mixer ready callback when provided', () => {
+    test('should invoke mixer ready callback when capture is ready', () => {
       const onData = jest.fn();
       const onError = jest.fn();
       const onMixerReady = jest.fn();
 
       store.initVoiceInput(onData, onError, onMixerReady);
 
-      expect(onAudioMixerReady).toHaveBeenCalledWith(onMixerReady);
-    });
-
-    test('should not register mixer callback when not provided', () => {
-      store.initVoiceInput(jest.fn(), jest.fn());
-
-      expect(onAudioMixerReady).not.toHaveBeenCalled();
+      expect(onMixerReady).toHaveBeenCalled();
     });
   });
 
@@ -381,6 +387,26 @@ describe('voiceStore', () => {
 
       expect(store.voiceHandlerReady.value).toBe(false);
     });
+
+    test('should stop active microphone capture', async () => {
+      await store.setupVoiceForConnection(true, 48000);
+
+      store.reset();
+
+      expect(mockStopVoiceInput).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stopVoiceCapture', () => {
+    test('should stop the active capture without ending the Mumble handler', async () => {
+      store.voiceHandler.value = mockVoiceHandler;
+      await store.setupVoiceForConnection(true, 48000);
+
+      store.stopVoiceCapture();
+
+      expect(mockStopVoiceInput).toHaveBeenCalledTimes(1);
+      expect(mockVoiceHandler.end).not.toHaveBeenCalled();
+    });
   });
 
   describe('setupVoiceForConnection', () => {
@@ -388,6 +414,24 @@ describe('voiceStore', () => {
       await store.setupVoiceForConnection(true, 48000);
 
       expect(initVoice).toHaveBeenCalled();
+    });
+
+    test('should reject when microphone capture fails to initialize', async () => {
+      const captureError = new Error('Permission denied');
+      initVoice.mockImplementationOnce((_onData, onError) => {
+        onError(captureError);
+        return mockStopVoiceInput;
+      });
+
+      await expect(store.setupVoiceForConnection(true, 48000)).rejects.toBe(captureError);
+    });
+
+    test('should not block voice readiness when optional beeper setup rejects', async () => {
+      const beeperError = new Error('Beeper setup failed');
+      mockAudioStore.initializePersistentBeeper.mockRejectedValueOnce(beeperError);
+
+      await expect(store.setupVoiceForConnection(true, 48000)).resolves.toEqual(expect.any(Function));
+      await Promise.resolve();
     });
 
     test('should activate audio lock when audio disabled', async () => {
@@ -406,6 +450,37 @@ describe('voiceStore', () => {
       await store.setupVoiceForConnection(true, 48000);
 
       expect(mockAudioStore.loadAudioWorkletModule).toHaveBeenCalledWith('playback-buffer-processor.js');
+    });
+
+    test('should not let an older setup cleanup stop newer capture', async () => {
+      let finishFirstResume;
+      const firstResume = new Promise(resolve => { finishFirstResume = resolve; });
+      const stopFirst = jest.fn();
+      const stopSecond = jest.fn();
+      initVoice
+        .mockImplementationOnce((_onData, _onError, onReady) => {
+          onReady({});
+          return stopFirst;
+        })
+        .mockImplementationOnce((_onData, _onError, onReady) => {
+          onReady({});
+          return stopSecond;
+        });
+      mockAudioStore.resumeAudioContext
+        .mockReturnValueOnce(firstResume)
+        .mockResolvedValueOnce(undefined);
+
+      const firstSetup = store.setupVoiceForConnection(true, 48000);
+      await Promise.resolve();
+      const secondCleanup = await store.setupVoiceForConnection(true, 48000);
+      finishFirstResume();
+      const firstCleanup = await firstSetup;
+
+      firstCleanup();
+      expect(stopSecond).not.toHaveBeenCalled();
+
+      secondCleanup();
+      expect(stopSecond).toHaveBeenCalledTimes(1);
     });
 
     test('should handle AudioContext resume failure gracefully', async () => {

--- a/__tests__/utils/stream-utils.test.js
+++ b/__tests__/utils/stream-utils.test.js
@@ -182,6 +182,16 @@ describe('websocket-stream-lite', () => {
       done();
     });
   });
+
+  it('should close socket when the stream is destroyed', (done) => {
+    const stream = websocketStream('wss://example.com');
+
+    stream.destroy();
+    stream.on('close', () => {
+      expect(mockSocket.close).toHaveBeenCalled();
+      done();
+    });
+  });
 });
 
 describe('duplexer-lite', () => {

--- a/__tests__/worker-client.test.js
+++ b/__tests__/worker-client.test.js
@@ -243,6 +243,29 @@ describe('WorkerBasedMumbleConnector', () => {
       expect(client).toBeDefined();
       expect(client._id).toBe('client-id-123');
     });
+
+    test('cancels the worker handshake when the abort signal fires', async () => {
+      const controller = new AbortController();
+      const connectPromise = connector.connect('test.server.com', {}, {
+        signal: controller.signal,
+      });
+      const reqId = connector._reqId - 1;
+
+      controller.abort();
+
+      await expect(connectPromise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(mockWorker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: '_cancelConnect',
+          payload: { reqId },
+        }),
+        undefined
+      );
+      expect(connector._requests[reqId]).toBeUndefined();
+
+      mockWorker._simulateMessage({ reqId, result: 'stale-client' });
+      expect(connector._clients['stale-client']).toBeUndefined();
+    });
   });
 
   describe('_client', () => {

--- a/__tests__/worker-client.test.js
+++ b/__tests__/worker-client.test.js
@@ -261,10 +261,37 @@ describe('WorkerBasedMumbleConnector', () => {
         }),
         undefined
       );
-      expect(connector._requests[reqId]).toBeUndefined();
+      expect(connector._requests[reqId]).toBeDefined();
 
       mockWorker._simulateMessage({ reqId, result: 'stale-client' });
       expect(connector._clients['stale-client']).toBeUndefined();
+      expect(mockWorker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: 'stale-client',
+          method: 'disconnect',
+        }),
+        undefined
+      );
+      expect(connector._requests[reqId]).toBeUndefined();
+    });
+
+    test('clears cancelled connection state after the worker acknowledges cancellation', async () => {
+      const controller = new AbortController();
+      const connectPromise = connector.connect('test.server.com', {}, {
+        signal: controller.signal,
+      });
+      const reqId = connector._reqId - 1;
+
+      controller.abort();
+      await expect(connectPromise).rejects.toMatchObject({ name: 'AbortError' });
+
+      mockWorker._simulateMessage({ reqId, result: null });
+
+      expect(connector._requests[reqId]).toBeUndefined();
+      expect(mockWorker.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'disconnect' }),
+        undefined
+      );
     });
   });
 

--- a/__tests__/worker.test.js
+++ b/__tests__/worker.test.js
@@ -232,7 +232,8 @@ describe("worker.js", () => {
 
       expect(mumbleConnectMock).toHaveBeenCalledWith(
         "wss://example.com",
-        expect.objectContaining({ username: "test" })
+        expect.objectContaining({ username: "test" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
       expect(globalThis.self.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ reqId: 1, result: clientId }),
@@ -249,6 +250,39 @@ describe("worker.js", () => {
       expect(globalThis.self.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ event: "denied", value: [denialReason] }),
         undefined
+      );
+    });
+
+    test("should abort and discard a cancelled pending connection", async () => {
+      let resolveConnection;
+      const client = createMockClient();
+      mumbleConnectMock.mockReturnValueOnce(new Promise(resolve => {
+        resolveConnection = resolve;
+      }));
+
+      messageHandler({
+        data: {
+          reqId: 77,
+          method: "_connect",
+          payload: { host: "wss://pending", args: {} },
+        },
+      });
+      const signal = mumbleConnectMock.mock.calls.at(-1)[2].signal;
+
+      messageHandler({
+        data: {
+          method: "_cancelConnect",
+          payload: { reqId: 77 },
+        },
+      });
+
+      expect(signal.aborted).toBe(true);
+      resolveConnection(client);
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(postMessageCalls).not.toContainEqual(
+        expect.objectContaining({ reqId: 77 })
       );
     });
   });

--- a/__tests__/worker.test.js
+++ b/__tests__/worker.test.js
@@ -281,8 +281,8 @@ describe("worker.js", () => {
       await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(client.disconnect).toHaveBeenCalled();
-      expect(postMessageCalls).not.toContainEqual(
-        expect.objectContaining({ reqId: 77 })
+      expect(postMessageCalls).toContainEqual(
+        expect.objectContaining({ reqId: 77, result: null })
       );
     });
   });

--- a/app/audio/audio-context-manager.js
+++ b/app/audio/audio-context-manager.js
@@ -242,6 +242,10 @@ class AudioContextManager {
    * Suspend the audio context to save resources
    */
   async suspendAudioContext() {
+    if (this.suspendRequest) {
+      return this.suspendRequest;
+    }
+
     if (!this.audioContext || this.audioContext.state === 'suspended') {
       return;
     }

--- a/app/audio/audio-context-manager.js
+++ b/app/audio/audio-context-manager.js
@@ -21,6 +21,7 @@ class AudioContextManager {
   onSuspendCallbacks = [];
   onResumeCallbacks = [];
   suspendRequest = null;
+  transitionRequest = Promise.resolve();
 
   constructor() {
     this.setupUserInteractionDetection();
@@ -195,23 +196,11 @@ class AudioContextManager {
 
   // RESUME-LOGIC: Attempt to resume suspended AudioContext with retry logic
   // Uses exponential backoff to handle transient browser restrictions
-  async resumeAudioContext() {
-    if (this.suspendRequest) {
-      try {
-        await this.suspendRequest;
-      } catch {
-        return this.audioContext;
-      }
-    }
-
-    if (this.audioContext?.state !== 'suspended') {
-      return this.audioContext;
-    }
-
+  async resumeWithRetry(context) {
     try {
-      await this.audioContext.resume();
+      await context.resume();
       this.resumeAttempts = 0; // RESET-COUNTER: Reset on success for future resumes
-      return this.audioContext;
+      return context;
     } catch (error) {
       this.resumeAttempts++;
       console.warn('Failed to resume AudioContext (attempt %d):', this.resumeAttempts, error);
@@ -220,46 +209,51 @@ class AudioContextManager {
       // Handles browsers that need time before allowing resume
       if (this.resumeAttempts < AUDIO_CONFIG.MAX_RESUME_ATTEMPTS) {
         const delay = AUDIO_CONFIG.RESUME_RETRY_DELAY * Math.pow(2, this.resumeAttempts - 1);
-        
-        return new Promise((resolve, reject) => {
-          setTimeout(async () => {
-            try {
-              const result = await this.resumeAudioContext();
-              resolve(result);
-            } catch (retryError) {
-              reject(retryError);
-            }
-          }, delay);
-        });
-      } else {
-        console.error('Max resume attempts reached');
-        throw error;
+
+        await new Promise(resolve => setTimeout(resolve, delay));
+        return this.resumeWithRetry(context);
       }
+
+      console.error('Max resume attempts reached');
+      throw error;
     }
+  }
+
+  resumeAudioContext() {
+    const resumeRequest = this.transitionRequest.catch(() => {}).then(() => {
+      if (this.audioContext?.state !== 'suspended') {
+        return this.audioContext;
+      }
+
+      return this.resumeWithRetry(this.audioContext);
+    });
+    this.transitionRequest = resumeRequest;
+    return resumeRequest;
   }
 
   /**
    * Suspend the audio context to save resources
    */
   async suspendAudioContext() {
-    if (this.suspendRequest) {
+    if (this.suspendRequest && this.transitionRequest === this.suspendRequest) {
       return this.suspendRequest;
     }
 
-    if (!this.audioContext || this.audioContext.state === 'suspended') {
-      return;
-    }
+    const suspendRequest = this.transitionRequest.catch(() => {}).then(async () => {
+      const context = this.audioContext;
+      if (!context || context.state === 'suspended') {
+        return;
+      }
 
-    const context = this.audioContext;
-    const suspendRequest = (async () => {
       try {
         await context.suspend();
       } catch (error) {
         console.error('Failed to suspend AudioContext:', error);
         throw error;
       }
-    })();
+    });
     this.suspendRequest = suspendRequest;
+    this.transitionRequest = suspendRequest;
 
     try {
       await suspendRequest;

--- a/app/audio/audio-context-manager.js
+++ b/app/audio/audio-context-manager.js
@@ -20,6 +20,7 @@ class AudioContextManager {
   onReadyCallbacks = [];
   onSuspendCallbacks = [];
   onResumeCallbacks = [];
+  suspendRequest = null;
 
   constructor() {
     this.setupUserInteractionDetection();
@@ -195,6 +196,14 @@ class AudioContextManager {
   // RESUME-LOGIC: Attempt to resume suspended AudioContext with retry logic
   // Uses exponential backoff to handle transient browser restrictions
   async resumeAudioContext() {
+    if (this.suspendRequest) {
+      try {
+        await this.suspendRequest;
+      } catch {
+        return this.audioContext;
+      }
+    }
+
     if (this.audioContext?.state !== 'suspended') {
       return this.audioContext;
     }
@@ -237,11 +246,21 @@ class AudioContextManager {
       return;
     }
 
+    const context = this.audioContext;
+    const suspendRequest = (async () => {
+      try {
+        await context.suspend();
+      } catch (error) {
+        console.error('Failed to suspend AudioContext:', error);
+        throw error;
+      }
+    })();
+    this.suspendRequest = suspendRequest;
+
     try {
-      await this.audioContext.suspend();
-    } catch (error) {
-      console.error('Failed to suspend AudioContext:', error);
-      throw error;
+      await suspendRequest;
+    } finally {
+      if (this.suspendRequest === suspendRequest) this.suspendRequest = null;
     }
   }
 

--- a/app/audio/voice.js
+++ b/app/audio/voice.js
@@ -235,7 +235,7 @@ export function onAudioMixerReady(callback) {
   }
 }
 
-function cleanupVoiceCapture(capture) {
+function removeTrackEndedHandlers(capture) {
   for (const [track, handler] of capture.trackEndedHandlers) {
     try {
       track.removeEventListener('ended', handler);
@@ -244,7 +244,9 @@ function cleanupVoiceCapture(capture) {
     }
   }
   capture.trackEndedHandlers.clear();
+}
 
+function stopCaptureTracks(capture) {
   for (const track of capture.userMedia?.getTracks?.() || []) {
     if (capture.stoppedTracks.has(track)) continue;
     capture.stoppedTracks.add(track);
@@ -254,7 +256,9 @@ function cleanupVoiceCapture(capture) {
       console.warn('[VOICE] Error stopping microphone track:', error_);
     }
   }
+}
 
+function disconnectCaptureNodes(capture) {
   for (const [node, label] of [
     [capture.node, 'AudioWorkletNode'],
     [capture.mixer, 'mixer'],
@@ -268,24 +272,53 @@ function cleanupVoiceCapture(capture) {
       console.warn(`[VOICE] Error disconnecting ${label}:`, error_);
     }
   }
+}
 
-  if (
-    capture.mixer &&
+function releaseCurrentMixer(capture) {
+  const ownsCurrentMixer = capture.mixer &&
     currentMixerInstance === capture.mixer &&
-    currentMixerTimestamp === capture.mixerTimestamp
-  ) {
-    currentMixerInstance = null;
-    globalThis._audioMixer = null;
+    currentMixerTimestamp === capture.mixerTimestamp;
+  if (!ownsCurrentMixer) return;
 
-    if (!capture.suspended) {
-      capture.suspended = true;
-      try {
-        audioContextManager.suspendAudioContext();
-      } catch (error_) {
-        console.warn('[VOICE] Error suspending AudioContext:', error_);
-      }
-    }
+  currentMixerInstance = null;
+  globalThis._audioMixer = null;
+  if (capture.suspended) return;
+
+  capture.suspended = true;
+  try {
+    audioContextManager.suspendAudioContext();
+  } catch (error_) {
+    console.warn('[VOICE] Error suspending AudioContext:', error_);
   }
+}
+
+function cleanupVoiceCapture(capture) {
+  removeTrackEndedHandlers(capture);
+  stopCaptureTracks(capture);
+  disconnectCaptureNodes(capture);
+  releaseCurrentMixer(capture);
+}
+
+function createVoiceCapture() {
+  return {
+    cancelled: false,
+    userMedia: null,
+    src: null,
+    mixer: null,
+    node: null,
+    mixerTimestamp: 0,
+    stoppedTracks: new Set(),
+    disconnectedNodes: new Set(),
+    trackEndedHandlers: new Map(),
+    suspended: false,
+  };
+}
+
+function createStopCapture(capture) {
+  return () => {
+    capture.cancelled = true;
+    cleanupVoiceCapture(capture);
+  };
 }
 
 async function handleUserMediaSuccess(userMedia, onData, onUserMediaError, onReady, capture) {
@@ -410,28 +443,14 @@ export function initVoice(onData, onUserMediaError, onReady) {
     },
   };
 
-  const capture = {
-    cancelled: false,
-    userMedia: null,
-    src: null,
-    mixer: null,
-    node: null,
-    mixerTimestamp: 0,
-    stoppedTracks: new Set(),
-    disconnectedNodes: new Set(),
-    trackEndedHandlers: new Map(),
-    suspended: false,
-  };
-  const stopCapture = () => {
-    capture.cancelled = true;
-    cleanupVoiceCapture(capture);
-  };
+  const capture = createVoiceCapture();
+  const stopCapture = createStopCapture(capture);
 
   if (!navigator.mediaDevices?.getUserMedia) {
     const error = new Error("MediaStreamError");
     error.name = "NotSupportedError";
     onUserMediaError(error);
-    return stopCapture;
+    return;
   }
 
   navigator.mediaDevices.getUserMedia(constraints)

--- a/app/audio/voice.js
+++ b/app/audio/voice.js
@@ -259,6 +259,7 @@ function stopCaptureTracks(capture) {
 }
 
 function disconnectCaptureNodes(capture) {
+  if (capture.node?.port) capture.node.port.onmessage = null;
   for (const [node, label] of [
     [capture.node, 'AudioWorkletNode'],
     [capture.mixer, 'mixer'],
@@ -286,7 +287,9 @@ function releaseCurrentMixer(capture) {
 
   capture.suspended = true;
   try {
-    audioContextManager.suspendAudioContext();
+    Promise.resolve(audioContextManager.suspendAudioContext()).catch(error_ => {
+      console.warn('[VOICE] Error suspending AudioContext:', error_);
+    });
   } catch (error_) {
     console.warn('[VOICE] Error suspending AudioContext:', error_);
   }
@@ -380,6 +383,7 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError, onRea
     // PCM-PIPELINE: Receive PCM frames from AudioWorklet and send to voice pipeline
     // Frame size: 960 samples @ 48kHz = 20ms (standard Mumble frame duration)
     node.port.onmessage = (ev) => {
+      if (capture.cancelled) return;
       if (ev.data?.type === "pcm" && ev.data.data) {
         const f32 = new Float32Array(ev.data.data);
         // NOTE: Debug logging removed - was using undefined 'this._isLoopbackMode'

--- a/app/audio/voice.js
+++ b/app/audio/voice.js
@@ -214,7 +214,7 @@ export function getCurrentMixer() {
 export function onAudioMixerReady(callback) {
   if (typeof callback !== 'function') {
     console.error('[VOICE] onAudioMixerReady: callback must be a function');
-    return;
+    return () => {};
   }
   
   // If mixer is already available, call immediately
@@ -224,49 +224,80 @@ export function onAudioMixerReady(callback) {
     } catch (err) {
       console.error('[VOICE] Error in mixer ready callback:', err);
     }
+    return () => {};
   } else {
     // Otherwise, queue for later
     audioMixerReadyCallbacks.push(callback);
+    return () => {
+      const index = audioMixerReadyCallbacks.indexOf(callback);
+      if (index !== -1) audioMixerReadyCallbacks.splice(index, 1);
+    };
   }
 }
 
-function handleTrackEnded(track, mixer, node, src, mixerTimestamp) {
-  if (currentMixerInstance === mixer && currentMixerTimestamp === mixerTimestamp) {
+function cleanupVoiceCapture(capture) {
+  for (const [track, handler] of capture.trackEndedHandlers) {
+    try {
+      track.removeEventListener('ended', handler);
+    } catch (error_) {
+      console.warn('[VOICE] Error removing track listener:', error_);
+    }
+  }
+  capture.trackEndedHandlers.clear();
+
+  for (const track of capture.userMedia?.getTracks?.() || []) {
+    if (capture.stoppedTracks.has(track)) continue;
+    capture.stoppedTracks.add(track);
+    try {
+      track.stop();
+    } catch (error_) {
+      console.warn('[VOICE] Error stopping microphone track:', error_);
+    }
+  }
+
+  for (const [node, label] of [
+    [capture.node, 'AudioWorkletNode'],
+    [capture.mixer, 'mixer'],
+    [capture.src, 'source'],
+  ]) {
+    if (!node || capture.disconnectedNodes.has(node)) continue;
+    capture.disconnectedNodes.add(node);
     try {
       node.disconnect();
     } catch (error_) {
-      console.warn('[VOICE] Error disconnecting AudioWorkletNode:', error_);
+      console.warn(`[VOICE] Error disconnecting ${label}:`, error_);
     }
-    try {
-      mixer.disconnect();
-    } catch (error_) {
-      console.warn('[VOICE] Error disconnecting mixer:', error_);
-    }
-    try {
-      src.disconnect();
-    } catch (error_) {
-      console.warn('[VOICE] Error disconnecting source:', error_);
-    }
+  }
 
-    // Clear global references only if this is still the active instance
+  if (
+    capture.mixer &&
+    currentMixerInstance === capture.mixer &&
+    currentMixerTimestamp === capture.mixerTimestamp
+  ) {
     currentMixerInstance = null;
     globalThis._audioMixer = null;
 
-    // Don't close the shared/global AudioContext here. Suspending saves power without
-    // invalidating the shared instance held by the AudioContextManager.
-    try {
-      audioContextManager.suspendAudioContext();
-    } catch (error_) {
-      console.warn('[VOICE] Error suspending AudioContext:', error_);
+    if (!capture.suspended) {
+      capture.suspended = true;
+      try {
+        audioContextManager.suspendAudioContext();
+      } catch (error_) {
+        console.warn('[VOICE] Error suspending AudioContext:', error_);
+      }
     }
   }
 }
 
-async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
+async function handleUserMediaSuccess(userMedia, onData, onUserMediaError, onReady, capture) {
   const initStartTime = Date.now();
   debugLog('[VOICE-INIT]', 'Starting audio pipeline initialization');
 
   try {
+    if (capture.cancelled) {
+      cleanupVoiceCapture(capture);
+      return;
+    }
+
     // AUDIO-CONTEXT: Use managed AudioContext with autoplay policy handling
     // Sample rate must be 48kHz to match Mumble protocol requirements
     const acStartTime = Date.now();
@@ -274,19 +305,29 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
       sampleRate: 48000,
       latencyHint: 'interactive'
     });
+    if (capture.cancelled) {
+      cleanupVoiceCapture(capture);
+      return;
+    }
     debugLog('[VOICE-INIT]', `AudioContext ready after ${Date.now() - acStartTime}ms (state: ${ac.state}, sampleRate: ${ac.sampleRate}Hz)`);
 
     // AUDIOWORKLET: Load AudioWorklet processor for real-time audio capture
     // recorder-worker.js runs in audio thread for low-latency processing
     const workletStartTime = Date.now();
     await ac.audioWorklet.addModule("recorder-worker.js");
+    if (capture.cancelled) {
+      cleanupVoiceCapture(capture);
+      return;
+    }
     debugLog('[VOICE-INIT]', `AudioWorklet module loaded after ${Date.now() - workletStartTime}ms`);
 
     // AUDIO-SOURCE: Create audio source from microphone stream
     const src = ac.createMediaStreamSource(userMedia);
+    capture.src = src;
 
     // BEEP-MIXER: Create a mixer node to combine microphone + beep signals
     const mixer = ac.createGain();
+    capture.mixer = mixer;
     mixer.gain.setValueAtTime(1, ac.currentTime);
 
     // WORKLET-NODE: Create AudioWorklet node for mono audio processing
@@ -296,6 +337,12 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
       numberOfOutputs: 0, // No audio output needed - we only capture, not play back
       channelCount: 1, // Mono channel (Mumble protocol requirement)
     });
+    capture.node = node;
+
+    if (capture.cancelled) {
+      cleanupVoiceCapture(capture);
+      return;
+    }
 
     // PCM-PIPELINE: Receive PCM frames from AudioWorklet and send to voice pipeline
     // Frame size: 960 samples @ 48kHz = 20ms (standard Mumble frame duration)
@@ -313,6 +360,7 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
     mixer.connect(node);
 
     const mixerTimestamp = Date.now();
+    capture.mixerTimestamp = mixerTimestamp;
     currentMixerInstance = mixer;
     currentMixerTimestamp = mixerTimestamp;
 
@@ -328,11 +376,16 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
     }
     audioMixerReadyCallbacks.length = 0;
 
-    // optional: aufräumen, wenn das mediastream endet
-    for (const t of userMedia.getTracks()) {
-      t.addEventListener("ended", () => handleTrackEnded(t, mixer, node, src, mixerTimestamp));
+    for (const track of userMedia.getTracks()) {
+      const handleEnded = () => cleanupVoiceCapture(capture);
+      capture.trackEndedHandlers.set(track, handleEnded);
+      track.addEventListener('ended', handleEnded);
     }
+
+    onReady?.(mixer);
   } catch (e) {
+    cleanupVoiceCapture(capture);
+    if (capture.cancelled) return;
     console.error("AudioWorklet init failed:", e);
     onUserMediaError(e);
   }
@@ -342,7 +395,7 @@ async function handleUserMediaSuccess(userMedia, onData, onUserMediaError) {
  * Init microphone capture.
  * Liefert per onData PCM-Frames (Float32) weiter – wie bisher, nur stabil via AudioWorklet.
  */
-export function initVoice(onData, onUserMediaError) {
+export function initVoice(onData, onUserMediaError, onReady) {
   const audioInputSelect = getAudioInputSelect();
   const audioSource = audioInputSelect?.value;
 
@@ -357,18 +410,43 @@ export function initVoice(onData, onUserMediaError) {
     },
   };
 
+  const capture = {
+    cancelled: false,
+    userMedia: null,
+    src: null,
+    mixer: null,
+    node: null,
+    mixerTimestamp: 0,
+    stoppedTracks: new Set(),
+    disconnectedNodes: new Set(),
+    trackEndedHandlers: new Map(),
+    suspended: false,
+  };
+  const stopCapture = () => {
+    capture.cancelled = true;
+    cleanupVoiceCapture(capture);
+  };
+
   if (!navigator.mediaDevices?.getUserMedia) {
     const error = new Error("MediaStreamError");
     error.name = "NotSupportedError";
     onUserMediaError(error);
-    return;
+    return stopCapture;
   }
 
   navigator.mediaDevices.getUserMedia(constraints)
     .then(userMedia => {
-      handleUserMediaSuccess(userMedia, onData, onUserMediaError);
+      capture.userMedia = userMedia;
+      if (capture.cancelled) {
+        cleanupVoiceCapture(capture);
+        return;
+      }
+      return handleUserMediaSuccess(userMedia, onData, onUserMediaError, onReady, capture);
     })
     .catch(err => {
-      onUserMediaError(err);
+      cleanupVoiceCapture(capture);
+      if (!capture.cancelled) onUserMediaError(err);
     });
+
+  return stopCapture;
 }

--- a/app/auth/AuthProvider.js
+++ b/app/auth/AuthProvider.js
@@ -40,6 +40,14 @@ class AuthProvider {
   }
 
   /**
+   * Get an access token for the Flexpair credentials endpoint
+   * @returns {Promise<string|null>} Access token or null if not authenticated
+   */
+  async getAccessToken() {
+    throw new Error('Method getAccessToken() must be implemented by subclass');
+  }
+
+  /**
    * Open login interface (modal, redirect, etc.)
    * Implementation depends on provider's UI/UX
    * @param {string} [view='login'] - 'login' or 'signup'

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -223,10 +223,9 @@ class NetlifyIdentityAdapter extends AuthProvider {
    * @param {Object} [options]
    * @param {boolean} [options.suppressProviderEvent=false] - Suppress the provider event
    * that belongs to this logout operation
-   * @param {AbortSignal} [options.signal] - Abort waiting for the provider event
    * @returns {Promise<void>}
    */
-  async logout({ suppressProviderEvent = false, signal } = {}) {
+  async logout({ suppressProviderEvent = false } = {}) {
     const run = () => new Promise((resolve, reject) => {
       const operation = { suppressProviderEvent };
       let settled = false;
@@ -234,21 +233,14 @@ class NetlifyIdentityAdapter extends AuthProvider {
         if (settled) return;
         settled = true;
         this.netlifyIdentity.off('logout', done);
-        signal?.removeEventListener('abort', abort);
         if (this._activeLogoutOperation === operation) this._activeLogoutOperation = null;
         if (error) reject(error);
         else resolve();
       };
       const done = () => finish();
-      const abort = () => finish(new DOMException('Logout aborted', 'AbortError'));
 
       this._activeLogoutOperation = operation;
       this.netlifyIdentity.on('logout', done);
-      if (signal?.aborted) {
-        abort();
-        return;
-      }
-      signal?.addEventListener('abort', abort, { once: true });
       try {
         Promise.resolve(this.netlifyIdentity.logout()).catch(finish);
       } catch (error) {

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -223,9 +223,10 @@ class NetlifyIdentityAdapter extends AuthProvider {
    * @param {Object} [options]
    * @param {boolean} [options.suppressProviderEvent=false] - Suppress the provider event
    * that belongs to this logout operation
+   * @param {AbortSignal} [options.signal] - Stop waiting for this operation
    * @returns {Promise<void>}
    */
-  async logout({ suppressProviderEvent = false } = {}) {
+  async logout({ suppressProviderEvent = false, signal } = {}) {
     const run = () => new Promise((resolve, reject) => {
       const operation = { suppressProviderEvent };
       let settled = false;
@@ -233,14 +234,21 @@ class NetlifyIdentityAdapter extends AuthProvider {
         if (settled) return;
         settled = true;
         this.netlifyIdentity.off('logout', done);
+        signal?.removeEventListener('abort', abort);
         if (this._activeLogoutOperation === operation) this._activeLogoutOperation = null;
         if (error) reject(error);
         else resolve();
       };
       const done = () => finish();
+      const abort = () => finish(new DOMException('Logout aborted', 'AbortError'));
 
       this._activeLogoutOperation = operation;
       this.netlifyIdentity.on('logout', done);
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
+      signal?.addEventListener('abort', abort, { once: true });
       try {
         Promise.resolve(this.netlifyIdentity.logout()).catch(finish);
       } catch (error) {

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -223,9 +223,10 @@ class NetlifyIdentityAdapter extends AuthProvider {
    * @param {Object} [options]
    * @param {boolean} [options.suppressProviderEvent=false] - Suppress the provider event
    * that belongs to this logout operation
+   * @param {AbortSignal} [options.signal] - Abort waiting for the provider event
    * @returns {Promise<void>}
    */
-  async logout({ suppressProviderEvent = false } = {}) {
+  async logout({ suppressProviderEvent = false, signal } = {}) {
     const run = () => new Promise((resolve, reject) => {
       const operation = { suppressProviderEvent };
       let settled = false;
@@ -233,14 +234,21 @@ class NetlifyIdentityAdapter extends AuthProvider {
         if (settled) return;
         settled = true;
         this.netlifyIdentity.off('logout', done);
+        signal?.removeEventListener('abort', abort);
         if (this._activeLogoutOperation === operation) this._activeLogoutOperation = null;
         if (error) reject(error);
         else resolve();
       };
       const done = () => finish();
+      const abort = () => finish(new DOMException('Logout aborted', 'AbortError'));
 
       this._activeLogoutOperation = operation;
       this.netlifyIdentity.on('logout', done);
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
+      signal?.addEventListener('abort', abort, { once: true });
       try {
         Promise.resolve(this.netlifyIdentity.logout()).catch(finish);
       } catch (error) {

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -23,7 +23,7 @@ class NetlifyIdentityAdapter extends AuthProvider {
     this._pendingHandlers = [];
     // Promise cache for _waitForWidget to prevent race conditions
     this._waitPromise = null;
-    this._logoutQueue = Promise.resolve();
+    this._logoutQueue = null;
     this._activeLogoutOperation = null;
     this._logoutHandlerWrappers = new Map();
     this.supportsLogoutEventSuppression = true;
@@ -248,7 +248,9 @@ class NetlifyIdentityAdapter extends AuthProvider {
       }
     });
 
-    const operation = this._logoutQueue.then(run, run);
+    const operation = this._logoutQueue
+      ? this._logoutQueue.then(run, run)
+      : run();
     this._logoutQueue = operation.catch(() => {});
     return operation;
   }

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -23,6 +23,10 @@ class NetlifyIdentityAdapter extends AuthProvider {
     this._pendingHandlers = [];
     // Promise cache for _waitForWidget to prevent race conditions
     this._waitPromise = null;
+    this._logoutQueue = Promise.resolve();
+    this._activeLogoutOperation = null;
+    this._logoutHandlerWrappers = new Map();
+    this.supportsLogoutEventSuppression = true;
   }
 
   /**
@@ -94,7 +98,7 @@ class NetlifyIdentityAdapter extends AuthProvider {
 
     // Register any event handlers that were queued before init()
     for (const { event, callback } of this._pendingHandlers) {
-      this.netlifyIdentity.on(event, callback);
+      this.netlifyIdentity.on(event, this._wrapLogoutHandler(event, callback));
     }
     this._pendingHandlers = [];
 
@@ -216,17 +220,47 @@ class NetlifyIdentityAdapter extends AuthProvider {
 
   /**
    * Log out current user
+   * @param {Object} [options]
+   * @param {boolean} [options.suppressProviderEvent=false] - Suppress the provider event
+   * that belongs to this logout operation
    * @returns {Promise<void>}
    */
-  async logout() {
-    return new Promise((resolve) => {
-      const done = () => {
+  async logout({ suppressProviderEvent = false } = {}) {
+    const run = () => new Promise((resolve, reject) => {
+      const operation = { suppressProviderEvent };
+      let settled = false;
+      const finish = (error) => {
+        if (settled) return;
+        settled = true;
         this.netlifyIdentity.off('logout', done);
-        resolve();
+        if (this._activeLogoutOperation === operation) this._activeLogoutOperation = null;
+        if (error) reject(error);
+        else resolve();
       };
+      const done = () => finish();
+
+      this._activeLogoutOperation = operation;
       this.netlifyIdentity.on('logout', done);
-      this.netlifyIdentity.logout();
+      try {
+        Promise.resolve(this.netlifyIdentity.logout()).catch(finish);
+      } catch (error) {
+        finish(error);
+      }
     });
+
+    const operation = this._logoutQueue.then(run, run);
+    this._logoutQueue = operation.catch(() => {});
+    return operation;
+  }
+
+  _wrapLogoutHandler(event, callback) {
+    if (event !== 'logout') return callback;
+    if (!this._logoutHandlerWrappers.has(callback)) {
+      this._logoutHandlerWrappers.set(callback, (...args) => {
+        if (!this._activeLogoutOperation?.suppressProviderEvent) callback(...args);
+      });
+    }
+    return this._logoutHandlerWrappers.get(callback);
   }
 
   /**
@@ -236,8 +270,9 @@ class NetlifyIdentityAdapter extends AuthProvider {
    * @param {Function} callback
    */
   on(event, callback) {
+    const handler = this._wrapLogoutHandler(event, callback);
     if (this.netlifyIdentity) {
-      this.netlifyIdentity.on(event, callback);
+      this.netlifyIdentity.on(event, handler);
     } else {
       // Queue for later registration after init()
       this._pendingHandlers.push({ event, callback });
@@ -250,14 +285,18 @@ class NetlifyIdentityAdapter extends AuthProvider {
    * @param {Function} callback
    */
   off(event, callback) {
+    const handler = event === 'logout'
+      ? this._logoutHandlerWrappers.get(callback) ?? callback
+      : callback;
     if (this.netlifyIdentity) {
-      this.netlifyIdentity.off(event, callback);
+      this.netlifyIdentity.off(event, handler);
     } else {
       // Remove from pending handlers if exists
       this._pendingHandlers = this._pendingHandlers.filter(
         h => !(h.event === event && h.callback === callback)
       );
     }
+    if (event === 'logout') this._logoutHandlerWrappers.delete(callback);
   }
 
   /**

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -90,7 +90,7 @@ class NetlifyIdentityAdapter extends AuthProvider {
       delete globalThis.__savedIdentityHash;
     }
 
-    this.netlifyIdentity.init(config);
+    this.netlifyIdentity.init(config?.netlify ?? config);
 
     // Register any event handlers that were queued before init()
     for (const { event, callback } of this._pendingHandlers) {
@@ -107,6 +107,14 @@ class NetlifyIdentityAdapter extends AuthProvider {
    */
   async getCurrentUser() {
     return this.netlifyIdentity.currentUser();
+  }
+
+  /**
+   * Get the current Netlify access token
+   * @returns {Promise<string|null>}
+   */
+  async getAccessToken() {
+    return this.netlifyIdentity.currentUser()?.token?.access_token || null;
   }
 
   /**

--- a/app/auth/credentials-service.js
+++ b/app/auth/credentials-service.js
@@ -45,6 +45,15 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 let pendingRequest = null;
 /** @type {string|null} */
 let pendingToken = null;
+let requestGeneration = 0;
+
+class SupersededCredentialsRequestError extends Error {
+  constructor() {
+    super('Credentials request superseded by a newer authentication session');
+    this.name = 'SupersededCredentialsRequestError';
+    this.code = 'CREDENTIALS_REQUEST_SUPERSEDED';
+  }
+}
 
 /**
  * Check if cache has expired
@@ -103,18 +112,26 @@ export async function fetchCredentials(token, { forceRefresh = false } = {}) {
   }
 
   // A different authenticated session must not await the previous session's
-  // request. Start an independent request for the new token.
+  // request. Invalidate its result so its caller cannot continue with stale
+  // Mumble or Guacamole credentials.
+  if (pendingRequest !== null && pendingToken !== token) {
+    requestGeneration += 1;
+  }
+
   const requestToken = token;
+  const requestGenerationAtStart = requestGeneration;
 
   const request = _fetchCredentialsFromServer(requestToken)
     .then(result => {
-      if (pendingRequest === request) {
-        cachedCredentials = result;
-        cachedToken = requestToken;
-        cacheTimestamp = Date.now();
-        pendingRequest = null;
-        pendingToken = null;
+      if (requestGenerationAtStart !== requestGeneration || pendingRequest !== request) {
+        throw new SupersededCredentialsRequestError();
       }
+
+      cachedCredentials = result;
+      cachedToken = requestToken;
+      cacheTimestamp = Date.now();
+      pendingRequest = null;
+      pendingToken = null;
       return result;
     })
     .catch(error => {
@@ -134,6 +151,7 @@ export async function fetchCredentials(token, { forceRefresh = false } = {}) {
  * Clear cached credentials (e.g., on logout)
  */
 export function clearCredentials() {
+  requestGeneration += 1;
   cachedCredentials = null;
   cachedToken = null;
   cacheTimestamp = null;

--- a/app/auth/credentials-service.js
+++ b/app/auth/credentials-service.js
@@ -21,6 +21,13 @@
 let cachedCredentials = null;
 
 /**
+ * Token associated with the cached credentials. Credentials must not be
+ * reused across authenticated sessions.
+ * @type {string|null}
+ */
+let cachedToken = null;
+
+/**
  * Cache timestamp for TTL-based invalidation
  * @type {number|null}
  */
@@ -36,6 +43,8 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
  * @type {Promise<ServerCredentials>|null}
  */
 let pendingRequest = null;
+/** @type {string|null} */
+let pendingToken = null;
 
 /**
  * Check if cache has expired
@@ -65,8 +74,6 @@ async function _fetchCredentialsFromServer(token) {
   }
 
   const credentials = await response.json();
-  cachedCredentials = credentials;
-  cacheTimestamp = Date.now();
   return credentials;
 }
 
@@ -86,26 +93,41 @@ export async function fetchCredentials(token, { forceRefresh = false } = {}) {
   }
 
   // Return cached credentials if available, not expired, and not forcing refresh
-  if (cachedCredentials && !isCacheExpired() && !forceRefresh) {
+  if (cachedCredentials && cachedToken === token && !isCacheExpired() && !forceRefresh) {
     return cachedCredentials;
   }
 
   // Prevent concurrent requests
-  if (pendingRequest !== null) {
+  if (pendingRequest !== null && pendingToken === token) {
     return pendingRequest;
   }
 
-  pendingRequest = _fetchCredentialsFromServer(token)
+  // A different authenticated session must not await the previous session's
+  // request. Start an independent request for the new token.
+  const requestToken = token;
+
+  const request = _fetchCredentialsFromServer(requestToken)
     .then(result => {
-      pendingRequest = null;
+      if (pendingRequest === request) {
+        cachedCredentials = result;
+        cachedToken = requestToken;
+        cacheTimestamp = Date.now();
+        pendingRequest = null;
+        pendingToken = null;
+      }
       return result;
     })
     .catch(error => {
-      pendingRequest = null;
+      if (pendingRequest === request) {
+        pendingRequest = null;
+        pendingToken = null;
+      }
       throw error;
     });
 
-  return pendingRequest;
+  pendingRequest = request;
+  pendingToken = requestToken;
+  return request;
 }
 
 /**
@@ -113,8 +135,10 @@ export async function fetchCredentials(token, { forceRefresh = false } = {}) {
  */
 export function clearCredentials() {
   cachedCredentials = null;
+  cachedToken = null;
   cacheTimestamp = null;
   pendingRequest = null;
+  pendingToken = null;
 }
 
 /**

--- a/app/auth/credentials-service.js
+++ b/app/auth/credentials-service.js
@@ -83,6 +83,10 @@ async function _fetchCredentialsFromServer(token) {
   }
 
   const credentials = await response.json();
+  const requiredFields = ['mumblePassword', 'guacamoleUser', 'guacamolePassword'];
+  if (!credentials || requiredFields.some(field => typeof credentials[field] !== 'string' || !credentials[field])) {
+    throw new Error('Credentials response is incomplete');
+  }
   return credentials;
 }
 
@@ -135,9 +139,13 @@ export async function fetchCredentials(token, { forceRefresh = false } = {}) {
       return result;
     })
     .catch(error => {
+      const superseded = requestGenerationAtStart !== requestGeneration || pendingRequest !== request;
       if (pendingRequest === request) {
         pendingRequest = null;
         pendingToken = null;
+      }
+      if (superseded && error?.code !== 'CREDENTIALS_REQUEST_SUPERSEDED') {
+        throw new SupersededCredentialsRequestError();
       }
       throw error;
     });

--- a/app/components/App.vue
+++ b/app/components/App.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup>
-import { Transition, ref, onMounted, useTemplateRef } from 'vue';
+import { Transition, ref, onMounted, useTemplateRef, watch } from 'vue';
 import { useUIStore } from '../stores/uiStore';
 
 // All components loaded synchronously (IIFE format doesn't support code-splitting)
@@ -80,6 +80,16 @@ const containerVisible = ref(true);
 
 // Ref to GuacamoleFrame component instance
 const guacamoleFrameRef = useTemplateRef('guacamoleFrameRef');
+const uiStore = useUIStore();
+
+// The child component ref may be populated after this component's mounted
+// hook. Keep the store reference synchronized so the first connection can
+// always hand off to Guacamole.
+watch(guacamoleFrameRef, (frame) => {
+  if (frame) {
+    uiStore.guacamoleFrame = frame;
+  }
+}, { immediate: true });
 
 // Handle preloader removal on window load
 onMounted(() => {
@@ -94,12 +104,6 @@ onMounted(() => {
     finalize();
   } else {
     globalThis.addEventListener('load', finalize, { once: true });
-  }
-  
-  // Wire up GuacamoleFrame reference to uiStore
-  if (guacamoleFrameRef.value) {
-    const uiStore = useUIStore();
-    uiStore.guacamoleFrame = guacamoleFrameRef.value;
   }
 });
 </script>

--- a/app/components/App.vue
+++ b/app/components/App.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup>
-import { Transition, ref, onMounted, useTemplateRef, watch } from 'vue';
+import { Transition, ref, onMounted, useTemplateRef } from 'vue';
 import { useUIStore } from '../stores/uiStore';
 
 // All components loaded synchronously (IIFE format doesn't support code-splitting)
@@ -80,16 +80,6 @@ const containerVisible = ref(true);
 
 // Ref to GuacamoleFrame component instance
 const guacamoleFrameRef = useTemplateRef('guacamoleFrameRef');
-const uiStore = useUIStore();
-
-// The child component ref may be populated after this component's mounted
-// hook. Keep the store reference synchronized so the first connection can
-// always hand off to Guacamole.
-watch(guacamoleFrameRef, (frame) => {
-  if (frame) {
-    uiStore.guacamoleFrame = frame;
-  }
-}, { immediate: true });
 
 // Handle preloader removal on window load
 onMounted(() => {
@@ -105,6 +95,9 @@ onMounted(() => {
   } else {
     globalThis.addEventListener('load', finalize, { once: true });
   }
+
+  const uiStore = useUIStore();
+  uiStore.guacamoleFrame = guacamoleFrameRef.value;
 });
 </script>
 

--- a/app/components/ConnectDialog.vue
+++ b/app/components/ConnectDialog.vue
@@ -142,6 +142,9 @@ import { useVoiceStore } from '../stores/voiceStore';
 import { useUserStore } from '../stores/userStore';
 import { useDialogStore } from '../stores/dialogStore';
 import { useConnectionLogic } from '../composables/useConnectionLogic';
+import { useConnectionStore } from '../stores/connectionStore';
+import { logoutSession } from '../composables/useAuthLogout';
+import { useUIStore } from '../stores/uiStore';
 import { announceToScreenReader } from '../composables/useAccessibility';
 
 /**
@@ -159,6 +162,8 @@ const auth = inject('auth');
 const audioStore = useAudioStore();
 const voiceStore = useVoiceStore();
 const userStore = useUserStore();
+const connectionStore = useConnectionStore();
+const uiStore = useUIStore();
 const dialogStore = useDialogStore();
 
 // Composables (for connection logic only)
@@ -298,15 +303,15 @@ function handleHide() {
 }
 
 async function handleLogout() {
-  try {
-    const { clearCredentials } = await import('../auth/credentials-service.js');
-    clearCredentials();
-    await auth.logout();
-  } catch (error) {
-    console.error('[ConnectDialog Vue] Logout failed', error);
-  } finally {
-    location.reload();
-  }
+  await logoutSession({
+    auth,
+    uiStore,
+    audioStore,
+    voiceStore,
+    connectionStore,
+    userStore,
+    dialogStore,
+  });
 }
 
 // Note: Escape key is intentionally disabled for Connect Dialog

--- a/app/components/ConnectDialog.vue
+++ b/app/components/ConnectDialog.vue
@@ -140,7 +140,6 @@ import { storeToRefs } from 'pinia';
 import { useAudioStore } from '../stores/audioStore';
 import { useVoiceStore } from '../stores/voiceStore';
 import { useUserStore } from '../stores/userStore';
-import { useUIStore } from '../stores/uiStore';
 import { useDialogStore } from '../stores/dialogStore';
 import { useConnectionLogic } from '../composables/useConnectionLogic';
 import { announceToScreenReader } from '../composables/useAccessibility';
@@ -240,41 +239,9 @@ onUnmounted(() => {
  * Handle form submission (Connect button)
  */
 async function handleConnect() {
-  // If in test mode and connected: exit test mode and switch to normal mode
-  if (isTestActive.value && connected.value) {
-    isTestActive.value = false;
-    voiceStore.isLoopbackMode = false;
-    
-    // Update voice handler to switch from loopback (target=31) to normal (target=0)
-    connectionLogic.updateVoiceHandler();
-    
-    // Setup and show Guacamole frame when exiting test mode
-    const uiStore = useUIStore();
-    if (uiStore.guacamoleFrame) {
-      // Get user roles to determine Guacamole access
-      const user_roles = (auth?.currentUser()?.app_metadata?.roles) || [];
-      const guac_login = connectionLogic.getGuacamoleLogin(user_roles);
-      
-      if (guac_login) {
-        uiStore.guacamoleFrame.start(guac_login, password.value);
-        uiStore.guacamoleFrame.show();
-      } else {
-        alert('For visual access please ask your administrator.');
-      }
-    }
-    
-    // Close dialog when switching from test to normal mode
-    visible.value = false;
-    return;
-  }
-  
-  // Normal connection flow (not in test mode)
-  if (!isTestActive.value) {
-    // Hide dialog before connecting
-    visible.value = false;
-    
-    await connectionLogic.connect(address.value, port.value, username.value, password.value);
-  }
+  isTestActive.value = false;
+  visible.value = false;
+  await connectionLogic.connect(address.value, port.value, username.value, password.value);
 }
 
 /**

--- a/app/components/ConnectErrorDialog.vue
+++ b/app/components/ConnectErrorDialog.vue
@@ -41,10 +41,17 @@
               <span v-if="type === 7" class="clientcert">
                 {{ translate('connectdialog.error.reason.clientcert') }}
               </span>
-              <br />
-              <span class="server"> {{ translate('connectdialog.error.reason.server') }} </span>
-              <br />
-              "<span class="connect-error-reason">{{ reason }}</span>"
+              <span v-if="type === 'generic'" class="generic">
+                {{ translate('connectdialog.error.reason.generic') }}
+              </span>
+              <template v-if="type !== 'generic'">
+                <br />
+                <span class="server"> {{ translate('connectdialog.error.reason.server') }} </span>
+                <br />
+              </template>
+              <span class="connect-error-reason">
+                {{ type !== 'generic' ? `"${reason}"` : reason }}
+              </span>
             </td>
           </tr>
           <tr v-if="type === 2 || type === 3 || type === 5">

--- a/app/components/GuacamoleFrame.vue
+++ b/app/components/GuacamoleFrame.vue
@@ -36,7 +36,7 @@
         :src="guacSource || 'about:blank'"
         @load="handleLoad"
         title="Remote Desktop - Interactive session"
-        loading="lazy"
+        loading="eager"
         allow="clipboard-read; clipboard-write"
         :aria-hidden="loading || !!error"
       ></iframe>

--- a/app/components/GuacamoleFrame.vue
+++ b/app/components/GuacamoleFrame.vue
@@ -34,7 +34,6 @@
         ref="guacamoleIframe"
         id="guacframe"
         :src="guacSource || 'about:blank'"
-        @load="handleLoad"
         title="Remote Desktop - Interactive session"
         loading="eager"
         allow="clipboard-read; clipboard-write"
@@ -44,7 +43,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, useTemplateRef, onWatcherCleanup } from 'vue';
+import { ref, watch, onMounted, useTemplateRef, onWatcherCleanup, nextTick } from 'vue';
 import {
   buildGuacamoleSource,
   clearGuacamoleSession,
@@ -79,7 +78,7 @@ let startupSequence = 0;
  * Focus the iframe when it becomes visible
  */
 function focusIframe() {
-  if (iframeRef.value && visible.value) {
+  if (iframeRef.value && visible.value && !loading.value && !error.value) {
     try {
       iframeRef.value.focus();
     } catch (e) {
@@ -146,10 +145,12 @@ function start(guacUser, password) {
     expectedSession: session,
     signal: controller.signal,
   })
-    .then(() => {
+    .then(async () => {
       if (startupController === controller) {
         startupController = null;
         loading.value = false;
+        await nextTick();
+        focusIframe();
       }
     })
     .catch(startupError => {
@@ -193,14 +194,6 @@ function stop() {
 }
 
 /**
- * Handle iframe load event
- */
-function handleLoad() {
-  // Focus iframe after content loads
-  focusIframe();
-}
-
-/**
  * Exposed Public API
  * 
  * These methods and properties are accessible from parent components
@@ -211,7 +204,6 @@ function handleLoad() {
  * @property {() => void} show - Show the frame
  * @property {() => void} hide - Hide the frame
  * @property {() => void} stop - Stop and unload the session
- * @property {() => void} handleLoad - Handle iframe load
  * @property {import('vue').Ref<string | null>} guacSource - Current iframe src
  * @property {import('vue').Ref<boolean>} visible - Visibility state
  * @property {import('vue').Ref<boolean>} loading - Loading state
@@ -222,7 +214,6 @@ defineExpose({
   show,
   hide,
   stop,
-  handleLoad,
   guacSource,
   visible,
   loading,

--- a/app/components/GuacamoleFrame.vue
+++ b/app/components/GuacamoleFrame.vue
@@ -38,6 +38,7 @@
         loading="eager"
         allow="clipboard-read; clipboard-write"
         :aria-hidden="loading || !!error"
+        :tabindex="loading || !!error ? -1 : 0"
       ></iframe>
   </section>
 </template>

--- a/app/components/GuacamoleFrame.vue
+++ b/app/components/GuacamoleFrame.vue
@@ -36,7 +36,7 @@
         :src="guacSource || 'about:blank'"
         @load="handleLoad"
         title="Remote Desktop - Interactive session"
-        loading="eager"
+        loading="lazy"
         allow="clipboard-read; clipboard-write"
         :aria-hidden="loading || !!error"
       ></iframe>
@@ -45,6 +45,11 @@
 
 <script setup>
 import { ref, watch, onMounted, useTemplateRef, onWatcherCleanup } from 'vue';
+import {
+  buildGuacamoleSource,
+  clearGuacamoleSession,
+  waitForGuacamoleReady,
+} from '../composables/useGuacamole';
 
 /**
  * GuacamoleFrame Component
@@ -67,6 +72,8 @@ const loading = ref(false);
 
 /** @type {import('vue').Ref<string | null>} */
 const error = ref(null);
+let startupController = null;
+let startupSequence = 0;
 
 /**
  * Focus the iframe when it becomes visible
@@ -108,6 +115,10 @@ onMounted(() => {
  * @param {string} password - Guacamole password
  */
 function start(guacUser, password) {
+  startupController?.abort();
+  clearGuacamoleSession();
+  const controller = new AbortController();
+  startupController = controller;
   loading.value = true;
   error.value = null;
 
@@ -128,14 +139,29 @@ function start(guacUser, password) {
     console.warn("[Guac] localStorage sanitization failed", e);
   }
 
-  // Build Guacamole URL with credentials
-  const src =
-    "/guacamole/#/?username=" +
-    guacUser +
-    "&password=" +
-    encodeURIComponent(password || "");
+  const session = String(++startupSequence);
 
-  guacSource.value = src;
+  guacSource.value = buildGuacamoleSource(guacUser, password, session);
+  return waitForGuacamoleReady(iframeRef.value, {
+    expectedSession: session,
+    signal: controller.signal,
+  })
+    .then(() => {
+      if (startupController === controller) {
+        startupController = null;
+        loading.value = false;
+      }
+    })
+    .catch(startupError => {
+      if (startupController === controller) {
+        startupController = null;
+        loading.value = false;
+        if (startupError.code !== 'GUACAMOLE_START_CANCELLED') {
+          error.value = startupError.message;
+        }
+      }
+      throw startupError;
+    });
 }
 
 /**
@@ -154,10 +180,22 @@ function hide() {
 }
 
 /**
+ * Stop and unload the Guacamole session.
+ */
+function stop() {
+  startupController?.abort();
+  startupController = null;
+  clearGuacamoleSession();
+  visible.value = false;
+  guacSource.value = null;
+  loading.value = false;
+  error.value = null;
+}
+
+/**
  * Handle iframe load event
  */
 function handleLoad() {
-  loading.value = false;
   // Focus iframe after content loads
   focusIframe();
 }
@@ -169,9 +207,10 @@ function handleLoad() {
  * via template ref (e.g., guacamoleFrameRef.value.show())
  * 
  * @typedef {Object} GuacamoleFrameAPI
- * @property {(guacUser: string, password: string) => void} start - Start Guacamole session
+ * @property {(guacUser: string, password: string) => Promise<void>} start - Start Guacamole session
  * @property {() => void} show - Show the frame
  * @property {() => void} hide - Hide the frame
+ * @property {() => void} stop - Stop and unload the session
  * @property {() => void} handleLoad - Handle iframe load
  * @property {import('vue').Ref<string | null>} guacSource - Current iframe src
  * @property {import('vue').Ref<boolean>} visible - Visibility state
@@ -182,6 +221,7 @@ defineExpose({
   start,
   show,
   hide,
+  stop,
   handleLoad,
   guacSource,
   visible,

--- a/app/components/GuacamoleFrame.vue
+++ b/app/components/GuacamoleFrame.vue
@@ -29,14 +29,14 @@
         {{ error }}
       </div>
 
-      <!-- iframe with lazy loading and clipboard permissions -->
+      <!-- iframe with clipboard permissions -->
       <iframe
         ref="guacamoleIframe"
         id="guacframe"
         :src="guacSource || 'about:blank'"
         @load="handleLoad"
         title="Remote Desktop - Interactive session"
-        loading="lazy"
+        loading="eager"
         allow="clipboard-read; clipboard-write"
         :aria-hidden="loading || !!error"
       ></iframe>
@@ -54,7 +54,7 @@ import {
 /**
  * GuacamoleFrame Component
  * 
- * Manages Guacamole remote desktop iframe with lazy loading and error handling.
+ * Manages the Guacamole remote desktop iframe and its error handling.
  * Exposes public API via defineExpose() for AppState integration.
  */
 

--- a/app/components/SampleRateWarningDialog.vue
+++ b/app/components/SampleRateWarningDialog.vue
@@ -142,7 +142,11 @@ const joinWithoutAudio = () => {
 };
 
 const cancel = () => {
+  const params = connectionParams.value;
   hide();
+  if (params) {
+    connectionLogic.cancelConnect(params);
+  }
 };
 
 // Methods are now available directly on the Pinia store (sampleRateWarningDialogStore)

--- a/app/components/Toolbar.vue
+++ b/app/components/Toolbar.vue
@@ -133,6 +133,8 @@ import { useUserStore } from '../stores/userStore';
 import { useAudioStore } from '../stores/audioStore';
 import { useUIStore } from '../stores/uiStore';
 import { useVoiceStore } from '../stores/voiceStore';
+import { useConnectionStore } from '../stores/connectionStore';
+import { invalidateConnectionAttempt } from '../composables/connectionAttempt';
 import { translate } from '../localize';
 import MessageConfirmation from './MessageConfirmation.vue';
 import packageJson from '../../package.json';
@@ -141,6 +143,7 @@ const userStore = useUserStore();
 const audioStore = useAudioStore();
 const uiStore = useUIStore();
 const voiceStore = useVoiceStore();
+const connectionStore = useConnectionStore();
 
 // Inject auth for logout
 const auth = inject('auth');
@@ -216,11 +219,23 @@ const handleSourceCodeClick = () => {
 };
 
 const handleLogoutClick = async () => {
-  // Clear cached credentials before logout
+  // Clear cached credentials and invalidate the active runtime immediately.
   const { clearCredentials } = await import('../auth/credentials-service.js');
   clearCredentials();
-  
-  await auth.logout();
+  invalidateConnectionAttempt();
+  uiStore.guacamoleFrame?.stop?.();
+  audioStore.stopBeep();
+  voiceStore.reset();
+  connectionStore.disconnect();
+  userStore.reset();
+
+  // Do not let an unresponsive provider logout keep stale app state alive.
+  await Promise.race([
+    auth.logout().catch((error) => {
+      console.error('[Auth] Logout failed:', error);
+    }),
+    new Promise(resolve => setTimeout(resolve, 1500)),
+  ]);
   location.reload();
 };
 </script>

--- a/app/components/Toolbar.vue
+++ b/app/components/Toolbar.vue
@@ -220,7 +220,7 @@ const handleLogoutClick = async () => {
   const { clearCredentials } = await import('../auth/credentials-service.js');
   clearCredentials();
   
-  auth.logout();
+  await auth.logout();
   location.reload();
 };
 </script>

--- a/app/components/Toolbar.vue
+++ b/app/components/Toolbar.vue
@@ -134,7 +134,7 @@ import { useAudioStore } from '../stores/audioStore';
 import { useUIStore } from '../stores/uiStore';
 import { useVoiceStore } from '../stores/voiceStore';
 import { useConnectionStore } from '../stores/connectionStore';
-import { invalidateConnectionAttempt } from '../composables/connectionAttempt';
+import { logoutSession } from '../composables/useAuthLogout';
 import { translate } from '../localize';
 import MessageConfirmation from './MessageConfirmation.vue';
 import packageJson from '../../package.json';
@@ -219,24 +219,15 @@ const handleSourceCodeClick = () => {
 };
 
 const handleLogoutClick = async () => {
-  // Clear cached credentials and invalidate the active runtime immediately.
-  const { clearCredentials } = await import('../auth/credentials-service.js');
-  clearCredentials();
-  invalidateConnectionAttempt();
-  uiStore.guacamoleFrame?.stop?.();
-  audioStore.stopBeep();
-  voiceStore.reset();
-  connectionStore.disconnect();
-  userStore.reset();
-
-  // Do not let an unresponsive provider logout keep stale app state alive.
-  await Promise.race([
-    auth.logout().catch((error) => {
-      console.error('[Auth] Logout failed:', error);
-    }),
-    new Promise(resolve => setTimeout(resolve, 1500)),
-  ]);
-  location.reload();
+  await logoutSession({
+    auth,
+    uiStore,
+    audioStore,
+    voiceStore,
+    connectionStore,
+    userStore,
+    dialogStore: null,
+  });
 };
 </script>
 

--- a/app/composables/connectionAttempt.js
+++ b/app/composables/connectionAttempt.js
@@ -1,0 +1,34 @@
+let activeAttempt = null;
+
+/**
+ * Begin a new application-wide connection attempt.
+ * Starting an attempt invalidates every earlier async handoff.
+ *
+ * @returns {symbol} Opaque attempt identifier
+ */
+export function beginConnectionAttempt() {
+  const id = Symbol('connection-attempt');
+  activeAttempt = id;
+  return id;
+}
+
+/**
+ * Check whether an async continuation still belongs to the active attempt.
+ *
+ * @param {symbol} attempt
+ * @returns {boolean}
+ */
+export function isConnectionAttemptCurrent(attempt) {
+  return activeAttempt === attempt;
+}
+
+/**
+ * Invalidate one attempt, or the active attempt when no identifier is supplied.
+ *
+ * @param {symbol} [attempt]
+ */
+export function invalidateConnectionAttempt(attempt) {
+  if (attempt === undefined || isConnectionAttemptCurrent(attempt)) {
+    activeAttempt = null;
+  }
+}

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -56,22 +56,17 @@ export async function logoutForReauthentication(
 ) {
   const suppressProviderEvent = auth.supportsLogoutEventSuppression === true;
   if (!suppressProviderEvent) suppressNextProviderLogout = true;
-  const controller = new AbortController();
   let providerLogoutObserved = false;
   let timedOut = false;
   let timeoutId;
   try {
     await Promise.race([
-      Promise.resolve().then(() => auth.logout({
-        suppressProviderEvent,
-        signal: controller.signal,
-      })).then(() => {
+      Promise.resolve().then(() => auth.logout({ suppressProviderEvent })).then(() => {
         providerLogoutObserved = true;
       }),
       new Promise(resolve => {
         timeoutId = setTimeout(() => {
           timedOut = true;
-          controller.abort();
           resolve();
         }, LOGOUT_TIMEOUT_MS);
       }),

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -52,12 +52,21 @@ export async function logoutSession(dependencies, reload = () => globalThis.loca
 
 export async function logoutForReauthentication(auth) {
   suppressNextProviderLogout = true;
+  let providerLogoutObserved = false;
+  let timeoutId;
   try {
     await Promise.race([
-      Promise.resolve().then(() => auth.logout()),
-      new Promise(resolve => setTimeout(resolve, LOGOUT_TIMEOUT_MS)),
+      Promise.resolve().then(() => auth.logout()).then(() => {
+        providerLogoutObserved = true;
+      }),
+      new Promise(resolve => {
+        timeoutId = setTimeout(resolve, LOGOUT_TIMEOUT_MS);
+      }),
     ]);
   } catch (error) {
     console.error('[Auth] Reauthentication logout failed:', error);
+  } finally {
+    clearTimeout(timeoutId);
+    if (!providerLogoutObserved) suppressNextProviderLogout = false;
   }
 }

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -50,24 +50,44 @@ export async function logoutSession(dependencies, reload = () => globalThis.loca
   reload();
 }
 
-export async function logoutForReauthentication(auth) {
+export async function logoutForReauthentication(
+  auth,
+  reload = () => globalThis.location.reload()
+) {
   const suppressProviderEvent = auth.supportsLogoutEventSuppression === true;
   if (!suppressProviderEvent) suppressNextProviderLogout = true;
+  const controller = new AbortController();
   let providerLogoutObserved = false;
+  let timedOut = false;
   let timeoutId;
   try {
     await Promise.race([
-      Promise.resolve().then(() => auth.logout({ suppressProviderEvent })).then(() => {
+      Promise.resolve().then(() => auth.logout({
+        suppressProviderEvent,
+        signal: controller.signal,
+      })).then(() => {
         providerLogoutObserved = true;
       }),
       new Promise(resolve => {
-        timeoutId = setTimeout(resolve, LOGOUT_TIMEOUT_MS);
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+          resolve();
+        }, LOGOUT_TIMEOUT_MS);
       }),
     ]);
   } catch (error) {
-    console.error('[Auth] Reauthentication logout failed:', error);
+    if (error?.name !== 'AbortError') {
+      console.error('[Auth] Reauthentication logout failed:', error);
+    }
   } finally {
     clearTimeout(timeoutId);
     if (!suppressProviderEvent && !providerLogoutObserved) suppressNextProviderLogout = false;
   }
+
+  if (timedOut) {
+    reload();
+    return false;
+  }
+  return true;
 }

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -1,0 +1,63 @@
+import { clearCredentials } from '../auth/credentials-service.js';
+import { invalidateConnectionAttempt } from './connectionAttempt.js';
+
+const LOGOUT_TIMEOUT_MS = 1500;
+let suppressNextProviderLogout = false;
+
+export function shouldHandleProviderLogout() {
+  if (!suppressNextProviderLogout) return true;
+  suppressNextProviderLogout = false;
+  return false;
+}
+
+export function resetSessionState({
+  uiStore,
+  audioStore,
+  voiceStore,
+  connectionStore,
+  userStore,
+  dialogStore,
+}) {
+  invalidateConnectionAttempt();
+  uiStore.guacamoleFrame?.stop?.();
+  audioStore.stopBeep();
+  voiceStore.reset();
+  connectionStore.disconnect();
+  userStore.reset();
+  dialogStore?.resetConnectDialog?.();
+  uiStore.reset();
+}
+
+export async function logoutSession(dependencies, reload = () => globalThis.location.reload()) {
+  suppressNextProviderLogout = false;
+  clearCredentials();
+  resetSessionState(dependencies);
+
+  let timeoutId;
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => dependencies.auth.logout()),
+      new Promise(resolve => {
+        timeoutId = setTimeout(resolve, LOGOUT_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (error) {
+    console.error('[Auth] Logout failed:', error);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  reload();
+}
+
+export async function logoutForReauthentication(auth) {
+  suppressNextProviderLogout = true;
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => auth.logout()),
+      new Promise(resolve => setTimeout(resolve, LOGOUT_TIMEOUT_MS)),
+    ]);
+  } catch (error) {
+    console.error('[Auth] Reauthentication logout failed:', error);
+  }
+}

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -51,12 +51,13 @@ export async function logoutSession(dependencies, reload = () => globalThis.loca
 }
 
 export async function logoutForReauthentication(auth) {
-  suppressNextProviderLogout = true;
+  const suppressProviderEvent = auth.supportsLogoutEventSuppression === true;
+  if (!suppressProviderEvent) suppressNextProviderLogout = true;
   let providerLogoutObserved = false;
   let timeoutId;
   try {
     await Promise.race([
-      Promise.resolve().then(() => auth.logout()).then(() => {
+      Promise.resolve().then(() => auth.logout({ suppressProviderEvent })).then(() => {
         providerLogoutObserved = true;
       }),
       new Promise(resolve => {
@@ -67,6 +68,6 @@ export async function logoutForReauthentication(auth) {
     console.error('[Auth] Reauthentication logout failed:', error);
   } finally {
     clearTimeout(timeoutId);
-    if (!providerLogoutObserved) suppressNextProviderLogout = false;
+    if (!suppressProviderEvent && !providerLogoutObserved) suppressNextProviderLogout = false;
   }
 }

--- a/app/composables/useAuthLogout.js
+++ b/app/composables/useAuthLogout.js
@@ -59,14 +59,19 @@ export async function logoutForReauthentication(
   let providerLogoutObserved = false;
   let timedOut = false;
   let timeoutId;
+  const controller = new AbortController();
   try {
     await Promise.race([
-      Promise.resolve().then(() => auth.logout({ suppressProviderEvent })).then(() => {
+      Promise.resolve().then(() => auth.logout({
+        suppressProviderEvent,
+        signal: controller.signal,
+      })).then(() => {
         providerLogoutObserved = true;
       }),
       new Promise(resolve => {
         timeoutId = setTimeout(() => {
           timedOut = true;
+          controller.abort();
           resolve();
         }, LOGOUT_TIMEOUT_MS);
       }),

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -99,7 +99,7 @@ export function useConnectionLogic({ auth } = {}) {
     if (!isConnectionAttemptCurrent(attempt)) return false;
     if (identity) return true;
 
-    await _requestLogin();
+    await _requestLogin({ attempt });
     return false;
   }
 
@@ -115,7 +115,7 @@ export function useConnectionLogic({ auth } = {}) {
     } catch (error) {
       if (!isConnectionAttemptCurrent(attempt) || isConnectionCancellation(error)) return null;
       console.error('[useConnectionLogic] Failed to fetch credentials:', error);
-      await _requestLogin({ logout: true });
+      await _requestLogin({ logout: true, attempt });
       return null;
     }
   }
@@ -295,20 +295,24 @@ export function useConnectionLogic({ auth } = {}) {
     }
   }
 
-  async function _requestLogin({ logout = false } = {}) {
+  async function _requestLogin({ logout = false, attempt } = {}) {
+    if (attempt && !isConnectionAttemptCurrent(attempt)) return;
     clearCredentials();
     _resetConnection();
+    const loginAttempt = beginConnectionAttempt();
     alert('Failed to authenticate. Please log in again.');
 
     if (logout) {
       try {
         if (!await logoutForReauthentication(auth)) return;
+        if (!isConnectionAttemptCurrent(loginAttempt)) return;
       } catch (error) {
         console.error('[useConnectionLogic] Failed to clear authentication session:', error);
       }
     }
 
     try {
+      if (!isConnectionAttemptCurrent(loginAttempt)) return;
       await auth.openAuth('login');
     } catch (error) {
       console.error('[useConnectionLogic] Failed to open authentication:', error);
@@ -327,11 +331,14 @@ export function useConnectionLogic({ auth } = {}) {
 
   function _initializeClientState(client, attempt) {
     connectionStore.registerChannel(client.root);
+    const isCurrent = () => (
+      isConnectionAttemptCurrent(attempt) && connectionStore.getClient() === client
+    );
     if (client.self) {
-      userStore.registerUser(client.self);
+      userStore.registerUser(client.self, isCurrent);
       userStore.thisUser = client.self.__ui;
     }
-    registerExistingUsers(client, userStore);
+    registerExistingUsers(client, userStore, isCurrent);
     _setupClientHandlers(client, attempt);
   }
 
@@ -350,7 +357,9 @@ export function useConnectionLogic({ auth } = {}) {
     // Register voice listeners for other users joining
     client.on('newUser', (user) => {
       if (!isConnectionAttemptCurrent(attempt)) return;
-      userStore.registerUser(user);
+      userStore.registerUser(user, () => (
+        isConnectionAttemptCurrent(attempt) && connectionStore.getClient() === client
+      ));
     });
     
     // Listen for messageSent event

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -363,6 +363,7 @@ export function useConnectionLogic({ auth } = {}) {
       uiStore.messageConfirmed = true;
       
       _messageConfirmationTimer = setTimeout(() => {
+        if (!isConnectionAttemptCurrent(attempt)) return;
         uiStore.messageConfirmed = false;
         _messageConfirmationTimer = null;
       }, 2000);

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -142,6 +142,7 @@ export function useConnectionLogic({ auth } = {}) {
   async function _setupConnection(params) {
     const { host, port, username, tokens = [], isLoopback = false } = params;
     _resetConnection();
+    dialogStore.connectDialog.isTestActive = isLoopback;
     const attempt = beginConnectionAttempt();
 
     // Auth check

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -86,6 +86,55 @@ export function useConnectionLogic({ auth } = {}) {
     });
   }
 
+  async function _ensureAuthenticated(attempt) {
+    let identity;
+    try {
+      identity = await auth.getCurrentUser();
+    } catch (error) {
+      if (!isConnectionAttemptCurrent(attempt)) return false;
+      console.error('[useConnectionLogic] Failed to read authentication session:', error);
+    }
+
+    if (!isConnectionAttemptCurrent(attempt)) return false;
+    if (identity) return true;
+
+    await _requestLogin();
+    return false;
+  }
+
+  async function _fetchServerCredentials(attempt) {
+    try {
+      const token = await auth.getAccessToken();
+      if (!isConnectionAttemptCurrent(attempt)) return null;
+      if (!token) throw new Error('No access token available');
+
+      const serverCredentials = await fetchCredentials(token);
+      if (!isConnectionAttemptCurrent(attempt)) return null;
+      return serverCredentials;
+    } catch (error) {
+      if (!isConnectionAttemptCurrent(attempt) || isConnectionCancellation(error)) return null;
+      console.error('[useConnectionLogic] Failed to fetch credentials:', error);
+      await _requestLogin({ logout: true });
+      return null;
+    }
+  }
+
+  async function _initializeAudioContext(attempt, connectionParams) {
+    if (audioStore.audioContext) return true;
+
+    try {
+      const audioContext = await audioStore.initializeAudioContext();
+      if (!isConnectionAttemptCurrent(attempt)) return false;
+      if (!audioContext && !audioStore.audioContext) {
+        throw new Error('AudioContext initialization failed');
+      }
+      return true;
+    } catch (error) {
+      _handleConnectionFailure(error, connectionParams, attempt);
+      return false;
+    }
+  }
+
   /**
    * Common connection setup for both normal and loopback modes
    * @private
@@ -101,38 +150,12 @@ export function useConnectionLogic({ auth } = {}) {
       alert('Authentication system not initialized. Please refresh the page.');
       return;
     }
-    
-    let identity;
-    try {
-      identity = await auth.getCurrentUser();
-    } catch (error) {
-      if (!isConnectionAttemptCurrent(attempt)) return;
-      console.error('[useConnectionLogic] Failed to read authentication session:', error);
-      await _requestLogin();
-      return;
-    }
-    if (!isConnectionAttemptCurrent(attempt)) return;
-    if (!identity) {
-      await _requestLogin();
-      return;
-    }
+
+    if (!(await _ensureAuthenticated(attempt))) return;
 
     // Fetch credentials from auth server (validates JWT server-side)
-    let serverCredentials;
-    try {
-      const token = await auth.getAccessToken();
-      if (!isConnectionAttemptCurrent(attempt)) return;
-      if (!token) {
-        throw new Error('No access token available');
-      }
-      serverCredentials = await fetchCredentials(token);
-      if (!isConnectionAttemptCurrent(attempt)) return;
-    } catch (error) {
-      if (isConnectionCancellation(error) || !isConnectionAttemptCurrent(attempt)) return;
-      console.error('[useConnectionLogic] Failed to fetch credentials:', error);
-      await _requestLogin({ logout: true });
-      return;
-    }
+    const serverCredentials = await _fetchServerCredentials(attempt);
+    if (!serverCredentials) return;
 
     // Use server-provided password
     const password = serverCredentials.mumblePassword;
@@ -148,16 +171,7 @@ export function useConnectionLogic({ auth } = {}) {
       attempt,
     };
 
-    try {
-      // Initialize AudioContext
-      if (!audioStore.audioContext) {
-        await audioStore.initializeAudioContext();
-        if (!isConnectionAttemptCurrent(attempt)) return;
-      }
-    } catch (error) {
-      _handleConnectionFailure(error, connectionParams, attempt);
-      return;
-    }
+    if (!(await _initializeAudioContext(attempt, connectionParams))) return;
 
     // Sample rate check (ONLY for normal mode, skip in loopback)
     if (!isLoopback) {

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -300,7 +300,10 @@ export function useConnectionLogic({ auth } = {}) {
 
     if (logout) {
       try {
-        await auth.logout();
+        await Promise.race([
+          auth.logout(),
+          new Promise(resolve => setTimeout(resolve, 1500)),
+        ]);
       } catch (error) {
         console.error('[useConnectionLogic] Failed to clear authentication session:', error);
       }

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -302,7 +302,7 @@ export function useConnectionLogic({ auth } = {}) {
 
     if (logout) {
       try {
-        await logoutForReauthentication(auth);
+        if (!await logoutForReauthentication(auth)) return;
       } catch (error) {
         console.error('[useConnectionLogic] Failed to clear authentication session:', error);
       }

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -102,6 +102,9 @@ export function useConnectionLogic({ auth } = {}) {
       }
       serverCredentials = await fetchCredentials(token);
     } catch (error) {
+      if (error?.code === 'CREDENTIALS_REQUEST_SUPERSEDED') {
+        return;
+      }
       console.error('[useConnectionLogic] Failed to fetch credentials:', error);
       alert('Failed to authenticate. Please log in again.');
       auth.logout();

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -120,7 +120,7 @@ export function useConnectionLogic({ auth } = {}) {
   }
 
   async function _initializeAudioContext(attempt, connectionParams) {
-    if (audioStore.audioContext) return true;
+    if (audioStore.audioContext) return isConnectionAttemptCurrent(attempt);
 
     try {
       const audioContext = await audioStore.initializeAudioContext();

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -192,13 +192,15 @@ export function useConnectionLogic({ auth } = {}) {
       voiceStore.isLoopbackMode = true;
     }
 
-    // Setup voice/audio
-    await voiceStore.setupVoiceForConnection(audioEnabled, sampleRate);
-
-    // Reset UI state
-    resetUIForConnection(audioStore, userStore, voiceStore);
-
     try {
+      // Setup voice/audio before opening the Mumble connection.
+      // Keep this inside the same error boundary so audio initialization
+      // failures are visible instead of silently aborting the handoff.
+      await voiceStore.setupVoiceForConnection(audioEnabled, sampleRate);
+
+      // Reset UI state
+      resetUIForConnection(audioStore, userStore, voiceStore);
+
       await _establishClientConnection(host, port, username, password, tokens, serverCredentials);
     } catch (err) {
       console.error('Connection failed:', err);

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -14,6 +14,7 @@ import {
   invalidateConnectionAttempt,
   isConnectionAttemptCurrent,
 } from './connectionAttempt.js';
+import { logoutForReauthentication } from './useAuthLogout.js';
 
 const CONNECTION_CANCELLED_CODES = new Set([
   'CONNECTION_ATTEMPT_SUPERSEDED',
@@ -301,10 +302,7 @@ export function useConnectionLogic({ auth } = {}) {
 
     if (logout) {
       try {
-        await Promise.race([
-          auth.logout(),
-          new Promise(resolve => setTimeout(resolve, 1500)),
-        ]);
+        await logoutForReauthentication(auth);
       } catch (error) {
         console.error('[useConnectionLogic] Failed to clear authentication session:', error);
       }

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -249,7 +249,7 @@ export function useConnectionLogic({ auth } = {}) {
       return;
     }
 
-    _initializeClientState(client);
+    _initializeClientState(client, attempt);
     _initializeAudio(client);
     await _initializeGuacamole(serverCredentials);
     if (!isConnectionAttemptCurrent(attempt)) return;
@@ -325,14 +325,14 @@ export function useConnectionLogic({ auth } = {}) {
     );
   }
 
-  function _initializeClientState(client) {
+  function _initializeClientState(client, attempt) {
     connectionStore.registerChannel(client.root);
     if (client.self) {
       userStore.registerUser(client.self);
       userStore.thisUser = client.self.__ui;
     }
     registerExistingUsers(client, userStore);
-    _setupClientHandlers(client);
+    _setupClientHandlers(client, attempt);
   }
 
   function _initializeAudio(client) {
@@ -346,14 +346,16 @@ export function useConnectionLogic({ auth } = {}) {
    * Setup minimal client event handlers
    * @private
    */
-  function _setupClientHandlers(client) {
+  function _setupClientHandlers(client, attempt) {
     // Register voice listeners for other users joining
     client.on('newUser', (user) => {
+      if (!isConnectionAttemptCurrent(attempt)) return;
       userStore.registerUser(user);
     });
     
     // Listen for messageSent event
     client.on('messageSent', (messageText) => {
+      if (!isConnectionAttemptCurrent(attempt)) return;
       if (_messageConfirmationTimer) {
         clearTimeout(_messageConfirmationTimer);
       }

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -268,7 +268,7 @@ export function useConnectionLogic({ auth } = {}) {
     uiStore.guacamoleFrame?.stop?.();
     audioStore.stopBeep();
     voiceStore.reset();
-    userStore.thisUser = null;
+    userStore.reset();
     dialogStore.connectDialog.isTestActive = false;
     audioStore.beeperReady = false;
     connectionStore.disconnect();

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -6,9 +6,25 @@ import { useUserStore } from '../stores/userStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { useDialogStore } from '../stores/dialogStore';
 import { translate } from '../localize';
-import { fetchCredentials } from '../auth/credentials-service.js';
-import { getGuacamoleLogin, getGuacamoleCredentials, startGuacamoleFrame, notifyGuacamoleUnavailable } from './useGuacamole';
+import { clearCredentials, fetchCredentials } from '../auth/credentials-service.js';
+import { startGuacamoleFrame } from './useGuacamole';
 import { registerExistingUsers, resetUIForConnection } from './useMumbleHelpers';
+import {
+  beginConnectionAttempt,
+  invalidateConnectionAttempt,
+  isConnectionAttemptCurrent,
+} from './connectionAttempt.js';
+
+const CONNECTION_CANCELLED_CODES = new Set([
+  'CONNECTION_ATTEMPT_SUPERSEDED',
+  'CREDENTIALS_REQUEST_SUPERSEDED',
+  'GUACAMOLE_START_CANCELLED',
+  'VOICE_CAPTURE_CANCELLED',
+]);
+
+function isConnectionCancellation(error) {
+  return CONNECTION_CANCELLED_CODES.has(error?.code);
+}
 
 /**
  * Composable for connection orchestration logic
@@ -30,9 +46,6 @@ export function useConnectionLogic({ auth } = {}) {
   
   // External dependencies
   const config = globalThis.mumbleWebConfig || {};
-  
-  // Connection tracking for race safety
-  let _currentConnectionId = null;
   
   // Timer tracking for message confirmation
   let _messageConfirmationTimer = null;
@@ -79,6 +92,8 @@ export function useConnectionLogic({ auth } = {}) {
    */
   async function _setupConnection(params) {
     const { host, port, username, tokens = [], isLoopback = false } = params;
+    _resetConnection();
+    const attempt = beginConnectionAttempt();
 
     // Auth check
     if (!auth) {
@@ -87,36 +102,61 @@ export function useConnectionLogic({ auth } = {}) {
       return;
     }
     
-    const identity = auth.currentUser();
+    let identity;
+    try {
+      identity = await auth.getCurrentUser();
+    } catch (error) {
+      if (!isConnectionAttemptCurrent(attempt)) return;
+      console.error('[useConnectionLogic] Failed to read authentication session:', error);
+      await _requestLogin();
+      return;
+    }
+    if (!isConnectionAttemptCurrent(attempt)) return;
     if (!identity) {
-      alert('You do not have permission to connect to the server. Please contact the administrator.');
+      await _requestLogin();
       return;
     }
 
     // Fetch credentials from auth server (validates JWT server-side)
     let serverCredentials;
     try {
-      const token = identity.token?.access_token || identity.access_token;
+      const token = await auth.getAccessToken();
+      if (!isConnectionAttemptCurrent(attempt)) return;
       if (!token) {
         throw new Error('No access token available');
       }
       serverCredentials = await fetchCredentials(token);
+      if (!isConnectionAttemptCurrent(attempt)) return;
     } catch (error) {
-      if (error?.code === 'CREDENTIALS_REQUEST_SUPERSEDED') {
-        return;
-      }
+      if (isConnectionCancellation(error) || !isConnectionAttemptCurrent(attempt)) return;
       console.error('[useConnectionLogic] Failed to fetch credentials:', error);
-      alert('Failed to authenticate. Please log in again.');
-      auth.logout();
+      await _requestLogin({ logout: true });
       return;
     }
 
     // Use server-provided password
     const password = serverCredentials.mumblePassword;
 
-    // Initialize AudioContext
-    if (!audioStore.audioContext) {
-      await audioStore.initializeAudioContext();
+    const connectionParams = {
+      host,
+      port,
+      username,
+      password,
+      tokens,
+      isLoopback,
+      serverCredentials,
+      attempt,
+    };
+
+    try {
+      // Initialize AudioContext
+      if (!audioStore.audioContext) {
+        await audioStore.initializeAudioContext();
+        if (!isConnectionAttemptCurrent(attempt)) return;
+      }
+    } catch (error) {
+      _handleConnectionFailure(error, connectionParams, attempt);
+      return;
     }
 
     // Sample rate check (ONLY for normal mode, skip in loopback)
@@ -125,7 +165,6 @@ export function useConnectionLogic({ auth } = {}) {
       const audioCompatible = currentSampleRate === 48000;
       
       if (!audioCompatible) {
-        const connectionParams = { host, port, username, password, tokens, serverCredentials };
         dialogStore.sampleRateDialog.sampleRate = currentSampleRate;
         dialogStore.sampleRateDialog.connectionParams = connectionParams;
         dialogStore.showSampleRateDialog();
@@ -133,48 +172,11 @@ export function useConnectionLogic({ auth } = {}) {
       }
     }
 
-    // Prepare connection parameters
-    const connectionParams = {
-      host, 
-      port, 
-      username, 
-      password, 
-      tokens,
-      isLoopback,
-      serverCredentials
-    };
-
-    // Request microphone permission
-    const connectionId = isLoopback ? Symbol('loopback-connection') : Symbol('connection');
-    _currentConnectionId = connectionId;
-    
-    if (navigator.mediaDevices?.getUserMedia) {
-      navigator.mediaDevices.getUserMedia({ audio: true })
-        .then(stream => {
-          // RACE-SAFE: Only update state if this connection is still active
-          if (_currentConnectionId === connectionId) {
-            audioStore.micPermissionDenied = false;
-          }
-          // Always stop tracks to avoid mic staying active
-          for (const track of stream.getTracks()) {
-            track.stop();
-          }
-        })
-        .catch(err => {
-          console.warn('Microphone permission denied:', err);
-          // RACE-SAFE: Only update state if this connection is still active
-          if (_currentConnectionId === connectionId) {
-            audioStore.micPermissionDenied = true;
-          }
-        });
-    }
-
     // Clear audio lock
     audioStore.clearAudioLock({ resetStates: true });
 
-    // Loopback-specific setup
+    voiceStore.isLoopbackMode = isLoopback;
     if (isLoopback) {
-      voiceStore.isLoopbackMode = true;
       // Ensure microphone is NOT muted for loopback test
       userStore.selfMute = false;
     }
@@ -188,8 +190,10 @@ export function useConnectionLogic({ auth } = {}) {
    * @private
    */
   async function _performConnect(connectionParams, { audioEnabled = true, sampleRate = null } = {}) {
-    const { host, port, username, password, tokens = [], serverCredentials } = connectionParams;
+    const { host, port, username, password, tokens = [], serverCredentials, attempt } = connectionParams;
     const isLoopback = connectionParams.isLoopback || false;
+
+    if (!attempt || !isConnectionAttemptCurrent(attempt)) return;
 
     if (isLoopback) {
       voiceStore.isLoopbackMode = true;
@@ -199,19 +203,18 @@ export function useConnectionLogic({ auth } = {}) {
       // Setup voice/audio before opening the Mumble connection.
       // Keep this inside the same error boundary so audio initialization
       // failures are visible instead of silently aborting the handoff.
-      await voiceStore.setupVoiceForConnection(audioEnabled, sampleRate);
+      const stopVoiceInput = await voiceStore.setupVoiceForConnection(audioEnabled, sampleRate);
+      if (!isConnectionAttemptCurrent(attempt)) {
+        stopVoiceInput?.();
+        return;
+      }
 
       // Reset UI state
       resetUIForConnection(audioStore, userStore, voiceStore);
 
-      await _establishClientConnection(host, port, username, password, tokens, serverCredentials);
+      await _establishClientConnection(host, port, username, password, tokens, serverCredentials, attempt);
     } catch (err) {
-      console.error('Connection failed:', err);
-      if (dialogStore) {
-         dialogStore.showErrorDialog(err, connectionParams);
-      } else {
-         alert('Connection failed: ' + err.message);
-      }
+      _handleConnectionFailure(err, connectionParams, attempt);
     }
   }
 
@@ -219,27 +222,91 @@ export function useConnectionLogic({ auth } = {}) {
    * Establish client connection and setup
    * @private
    */
-  async function _establishClientConnection(host, port, username, password, tokens, serverCredentials) {
+  async function _establishClientConnection(host, port, username, password, tokens, serverCredentials, attempt) {
     const client = await connectionStore.connect(host, port, username, password, tokens);
-    
-    _initializeGuacamole(serverCredentials, password);
-    
-    const logKey = voiceStore.isLoopbackMode ? 'logentry.connected_loopback' : 'logentry.connected';
-    console.log(translate(logKey));
+    if (!isConnectionAttemptCurrent(attempt)) {
+      if (connectionStore.getClient() === client) {
+        connectionStore.disconnect();
+      } else {
+        client.disconnect();
+      }
+      return;
+    }
 
     _initializeClientState(client);
     _initializeAudio(client);
+    await _initializeGuacamole(serverCredentials);
+    if (!isConnectionAttemptCurrent(attempt)) return;
+
+    const logKey = voiceStore.isLoopbackMode ? 'logentry.connected_loopback' : 'logentry.connected';
+    console.log(translate(logKey));
   }
 
-  function _initializeGuacamole(serverCredentials, password) {
+  function _resetConnection() {
+    if (_messageConfirmationTimer) {
+      clearTimeout(_messageConfirmationTimer);
+      _messageConfirmationTimer = null;
+    }
+
+    invalidateConnectionAttempt();
+    uiStore.guacamoleFrame?.stop?.();
+    audioStore.stopBeep();
+    voiceStore.reset();
+    userStore.thisUser = null;
+    dialogStore.connectDialog.isTestActive = false;
+    audioStore.beeperReady = false;
+    connectionStore.disconnect();
+  }
+
+  function cancelConnect(connectionParams) {
+    const attempt = connectionParams?.attempt;
+    if (!attempt || !isConnectionAttemptCurrent(attempt)) return;
+
+    clearCredentials();
+    _resetConnection();
+    dialogStore.showConnectDialog();
+  }
+
+  function _handleConnectionFailure(error, connectionParams, attempt) {
+    if (isConnectionCancellation(error) || !isConnectionAttemptCurrent(attempt)) return;
+
+    _resetConnection();
+    console.error('Connection failed:', error);
+    if (dialogStore) {
+      dialogStore.showErrorDialog(error, connectionParams);
+    } else {
+      alert('Connection failed: ' + error.message);
+    }
+  }
+
+  async function _requestLogin({ logout = false } = {}) {
+    clearCredentials();
+    _resetConnection();
+    alert('Failed to authenticate. Please log in again.');
+
+    if (logout) {
+      try {
+        await auth.logout();
+      } catch (error) {
+        console.error('[useConnectionLogic] Failed to clear authentication session:', error);
+      }
+    }
+
+    try {
+      await auth.openAuth('login');
+    } catch (error) {
+      console.error('[useConnectionLogic] Failed to open authentication:', error);
+    }
+  }
+
+  async function _initializeGuacamole(serverCredentials) {
     if (voiceStore.isLoopbackMode) return;
 
-    const guacCreds = getGuacamoleCredentials(serverCredentials, password, auth);
-    if (guacCreds.user) {
-      startGuacamoleFrame(guacCreds.user, guacCreds.password, uiStore);
-    } else {
-      notifyGuacamoleUnavailable();
-    }
+    await startGuacamoleFrame(
+      serverCredentials.guacamoleUser,
+      serverCredentials.guacamolePassword,
+      uiStore
+    );
   }
 
   function _initializeClientState(client) {
@@ -346,26 +413,7 @@ export function useConnectionLogic({ auth } = {}) {
   /**
    * Reset client and all state
    */
-  const resetClient = () => {
-    // Clear message confirmation timer
-    if (_messageConfirmationTimer) {
-      clearTimeout(_messageConfirmationTimer);
-      _messageConfirmationTimer = null;
-    }
-    
-    _currentConnectionId = null;
-    audioStore.stopBeep();
-    connectionStore.disconnect();
-    userStore.thisUser = null;
-    
-    const wasLoopback = voiceStore.isLoopbackMode;
-    voiceStore.isLoopbackMode = false;
-    
-    if (!wasLoopback) {
-      audioStore.beeperReady = false;
-      voiceStore.voiceHandlerReady = false;
-    }
-  };
+  const resetClient = () => _resetConnection();
 
   /**
    * Send message to channel or user
@@ -394,7 +442,7 @@ export function useConnectionLogic({ auth } = {}) {
     sendMessage,
     connected,
     updateVoiceHandler,
-    performConnect: _performConnect, // Export for SampleRateWarningDialog
-    getGuacamoleLogin // Export for ConnectDialog
+    cancelConnect,
+    performConnect: _performConnect // Export for SampleRateWarningDialog
   };
 }

--- a/app/composables/useGuacamole.js
+++ b/app/composables/useGuacamole.js
@@ -22,6 +22,42 @@ function isVisibleError(element, contentWindow) {
   return !style || (style.display !== 'none' && style.visibility !== 'hidden');
 }
 
+function isCurrentNavigation(iframe, expectedSession, navigationStartDocument) {
+  if (!expectedSession) return true;
+  let loadedSession;
+  try {
+    loadedSession = new URL(iframe.contentWindow?.location?.href)
+      .searchParams.get('flexpairSession');
+  } catch {
+    return false;
+  }
+  return loadedSession === String(expectedSession) &&
+    iframe.contentDocument !== navigationStartDocument;
+}
+
+function getGuacamoleAuthenticationService(iframe, document) {
+  try {
+    return iframe.contentWindow?.angular
+      ?.element(document.documentElement)
+      ?.injector?.()
+      ?.get('authenticationService');
+  } catch {
+    return undefined;
+  }
+}
+
+function hasVisibleGuacamoleError(document, contentWindow) {
+  return [...document.querySelectorAll(GUACAMOLE_ERROR_SELECTOR)]
+    .some(element => isVisibleError(element, contentWindow));
+}
+
+function hasLoadedNonGuacamoleDocument(document, href) {
+  const isComplete = document.readyState === 'complete';
+  const hasHref = href !== undefined && href !== null && href !== 'about:blank';
+  const isGuacamole = document.documentElement?.matches?.(GUACAMOLE_APP_SELECTOR) === true;
+  return isComplete && hasHref && !isGuacamole;
+}
+
 /**
  * Remove Guacamole's persisted authentication token so it cannot be reused
  * across Flexpair authentication sessions.
@@ -120,35 +156,16 @@ export function waitForGuacamoleReady(
 
       if (!document) return;
 
-      if (expectedSession) {
-        let loadedSession;
-        try {
-          loadedSession = new URL(href).searchParams.get('flexpairSession');
-        } catch {
-          return;
-        }
-        if (loadedSession !== String(expectedSession)) return;
-        // The new URL can be visible before the iframe swaps out its old document.
-        if (document === navigationStartDocument) return;
-      }
+      if (!isCurrentNavigation(iframe, expectedSession, navigationStartDocument)) return;
 
       const isGuacamole = document.documentElement?.matches?.(GUACAMOLE_APP_SELECTOR) === true;
-      let authenticationService;
-      try {
-        authenticationService = iframe.contentWindow?.angular
-          ?.element(document.documentElement)
-          ?.injector?.()
-          ?.get('authenticationService');
-      } catch {
-        return;
-      }
+      const authenticationService = getGuacamoleAuthenticationService(iframe, document);
 
       // Ignore the uncompiled Guacamole HTML. Its templates contain both
       // success and error elements before Angular has selected active views.
       if (isGuacamole && !authenticationService) return;
 
-      const errorElement = document.querySelector(GUACAMOLE_ERROR_SELECTOR);
-      if (isVisibleError(errorElement, iframe.contentWindow)) {
+      if (hasVisibleGuacamoleError(document, iframe.contentWindow)) {
         fail('Remote desktop authentication failed', 'GUACAMOLE_AUTH_FAILED');
         return;
       }
@@ -159,7 +176,7 @@ export function waitForGuacamoleReady(
         return;
       }
 
-      if (document.readyState === 'complete' && href && href !== 'about:blank' && !isGuacamole) {
+      if (hasLoadedNonGuacamoleDocument(document, href)) {
         fail('Remote desktop failed to load', 'GUACAMOLE_LOAD_FAILED');
       }
     }

--- a/app/composables/useGuacamole.js
+++ b/app/composables/useGuacamole.js
@@ -1,46 +1,199 @@
-/**
- * Determine Guacamole login role from user roles
- * @param {Array} roles - User roles array
- * @returns {string|false} - 'admin', 'editor', 'watcher', or false
- */
-export function getGuacamoleLogin(roles = []) {
-  if (roles.includes('admin')) return 'admin';
-  if (roles.includes('edit')) return 'editor';
-  if (roles.includes('watch')) return 'watcher';
-  return false;
+const GUACAMOLE_APP_SELECTOR = '[ng-app="index"]';
+const GUACAMOLE_AUTH_TOKEN_KEY = 'GUAC_AUTH_TOKEN';
+const GUACAMOLE_ERROR_SELECTOR = [
+  '.login-ui.error',
+  '.automatic-login-rejected-modal',
+  '.fatal-page-error-modal',
+  '.logged-out-modal',
+].join(', ');
+
+function createGuacamoleError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isVisibleError(element, contentWindow) {
+  if (!element || element.hidden || element.getAttribute?.('aria-hidden') === 'true') {
+    return false;
+  }
+
+  const style = contentWindow?.getComputedStyle?.(element);
+  return !style || (style.display !== 'none' && style.visibility !== 'hidden');
 }
 
 /**
- * Get Guacamole credentials from server or legacy fallback
- * @param {Object} serverCredentials
- * @param {string} password
- * @param {Object} auth
- * @returns {Object} {user, password}
+ * Remove Guacamole's persisted authentication token so it cannot be reused
+ * across Flexpair authentication sessions.
+ *
+ * @param {Storage} [storage]
  */
-export function getGuacamoleCredentials(serverCredentials, password, auth) {
-  const roles = auth?.currentUser()?.app_metadata?.roles || [];
-  return {
-    user: serverCredentials?.guacamoleUser || getGuacamoleLogin(roles),
-    password: serverCredentials?.guacamolePassword || password
-  };
-}
-
-/**
- * Start the Guacamole remote-desktop frame for an authorized user.
- * @param {string} guac_login
- * @param {string} password
- * @param {Object} uiStore
- */
-export function startGuacamoleFrame(guac_login, password, uiStore) {
-  if (uiStore.guacamoleFrame) {
-    uiStore.guacamoleFrame.start(guac_login, password);
-    uiStore.guacamoleFrame.show();
+export function clearGuacamoleSession(storage) {
+  try {
+    const sessionStorage = storage ?? globalThis.localStorage;
+    sessionStorage?.removeItem(GUACAMOLE_AUTH_TOKEN_KEY);
+  } catch (error) {
+    console.warn('[Guacamole] Could not clear stored session:', error);
   }
 }
 
 /**
- * Notify the user that visual access is unavailable (no Guacamole role).
+ * Build a Guacamole URL without allowing credential values to alter fragment
+ * parameters.
+ *
+ * @param {string} username
+ * @param {string} password
+ * @param {string} session
+ * @returns {string}
  */
-export function notifyGuacamoleUnavailable() {
-  alert('For visual access please ask your administrator.');
+export function buildGuacamoleSource(username, password, session) {
+  return '/guacamole/?flexpairSession=' + encodeURIComponent(session) +
+    '#/?username=' + encodeURIComponent(username || '') +
+    '&password=' + encodeURIComponent(password || '');
+}
+
+/**
+ * Wait until the same-origin Guacamole application has authenticated and
+ * rendered its usable content area.
+ *
+ * @param {HTMLIFrameElement} iframe
+ * @param {Object} [options]
+ * @param {number} [options.timeoutMs=30000]
+ * @param {number} [options.pollIntervalMs=50]
+ * @param {string} [options.expectedSession]
+ * @param {AbortSignal} [options.signal]
+ * @returns {Promise<void>}
+ */
+export function waitForGuacamoleReady(
+  iframe,
+  { timeoutMs = 30000, pollIntervalMs = 50, expectedSession, signal } = {}
+) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let pollTimer;
+    let timeoutTimer;
+    let navigationStartDocument;
+
+    const cleanup = () => {
+      clearInterval(pollTimer);
+      clearTimeout(timeoutTimer);
+      iframe.removeEventListener('load', inspect);
+      signal?.removeEventListener('abort', handleAbort);
+    };
+
+    const settle = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+
+    const fail = (message, code) => {
+      settle(reject, createGuacamoleError(message, code));
+    };
+
+    const handleAbort = () => {
+      fail('Remote desktop startup was cancelled', 'GUACAMOLE_START_CANCELLED');
+    };
+
+    if (expectedSession) {
+      try {
+        navigationStartDocument = iframe.contentDocument;
+      } catch {
+        fail('Remote desktop failed to load', 'GUACAMOLE_LOAD_FAILED');
+        return;
+      }
+    }
+
+    function inspect() {
+      if (settled) return;
+
+      let document;
+      let href;
+      try {
+        document = iframe.contentDocument;
+        href = iframe.contentWindow?.location?.href;
+      } catch {
+        fail('Remote desktop failed to load', 'GUACAMOLE_LOAD_FAILED');
+        return;
+      }
+
+      if (!document) return;
+
+      if (expectedSession) {
+        let loadedSession;
+        try {
+          loadedSession = new URL(href).searchParams.get('flexpairSession');
+        } catch {
+          return;
+        }
+        if (loadedSession !== String(expectedSession)) return;
+        // The new URL can be visible before the iframe swaps out its old document.
+        if (document === navigationStartDocument) return;
+      }
+
+      const isGuacamole = document.documentElement?.matches?.(GUACAMOLE_APP_SELECTOR) === true;
+      let authenticationService;
+      try {
+        authenticationService = iframe.contentWindow?.angular
+          ?.element(document.documentElement)
+          ?.injector?.()
+          ?.get('authenticationService');
+      } catch {
+        return;
+      }
+
+      // Ignore the uncompiled Guacamole HTML. Its templates contain both
+      // success and error elements before Angular has selected active views.
+      if (isGuacamole && !authenticationService) return;
+
+      const errorElement = document.querySelector(GUACAMOLE_ERROR_SELECTOR);
+      if (isVisibleError(errorElement, iframe.contentWindow)) {
+        fail('Remote desktop authentication failed', 'GUACAMOLE_AUTH_FAILED');
+        return;
+      }
+
+      const isAuthenticated = Boolean(authenticationService?.getCurrentToken?.());
+      if (isGuacamole && isAuthenticated && document.querySelector('#content')) {
+        settle(resolve);
+        return;
+      }
+
+      if (document.readyState === 'complete' && href && href !== 'about:blank' && !isGuacamole) {
+        fail('Remote desktop failed to load', 'GUACAMOLE_LOAD_FAILED');
+      }
+    }
+
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+
+    iframe.addEventListener('load', inspect);
+    signal?.addEventListener('abort', handleAbort, { once: true });
+    pollTimer = setInterval(inspect, pollIntervalMs);
+    timeoutTimer = setTimeout(
+      () => fail('Remote desktop timed out', 'GUACAMOLE_START_TIMEOUT'),
+      timeoutMs
+    );
+    inspect();
+  });
+}
+
+/**
+ * Start the Guacamole remote-desktop frame for an authorized user and wait
+ * until Guacamole confirms that authenticated content is usable.
+ * @param {string} guac_login
+ * @param {string} password
+ * @param {Object} uiStore
+ * @returns {Promise<void>}
+ */
+export async function startGuacamoleFrame(guac_login, password, uiStore) {
+  if (!uiStore.guacamoleFrame) {
+    throw new Error('Remote desktop is not ready');
+  }
+
+  const ready = uiStore.guacamoleFrame.start(guac_login, password);
+  uiStore.guacamoleFrame.show();
+  await ready;
 }

--- a/app/composables/useMumbleHelpers.js
+++ b/app/composables/useMumbleHelpers.js
@@ -3,10 +3,10 @@
  * @param {Object} client
  * @param {Object} userStore
  */
-export function registerExistingUsers(client, userStore) {
+export function registerExistingUsers(client, userStore, isCurrent) {
   for (const user of client.users.values()) {
     if (user !== client.self) {
-      userStore.registerUser(user);
+      userStore.registerUser(user, isCurrent);
     }
   }
 }

--- a/app/composables/useUserVoiceStream.js
+++ b/app/composables/useUserVoiceStream.js
@@ -140,7 +140,8 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
    * @param {object} ui - User UI object
    * @param {object} stream - Voice stream
    */
-  const handleVoiceStream = async (user, ui, stream) => {
+  const handleVoiceStream = async (user, ui, stream, isCurrent = () => true) => {
+    if (!isCurrent()) return;
     debugLog('[VOICE]', 'Voice stream received for user:', user.username, 'session:', user.session);
     
     const randomValue = crypto.getRandomValues(new Uint32Array(1))[0];
@@ -156,6 +157,11 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
       debugLog('[VOICE]', 'Initializing BufferQueueNode...');
       await userNode.initialize();
       debugLog('[VOICE]', '✅ BufferQueueNode initialized successfully');
+
+      if (!isCurrent()) {
+        userNode.end();
+        return;
+      }
       
       if (settingsStore.jitterBufferSize) {
          userNode.setJitterBufferSize(settingsStore.jitterBufferSize);
@@ -167,6 +173,11 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
         message: err.message,
         stack: err.stack
       });
+      return;
+    }
+
+    if (!isCurrent()) {
+      userNode.end();
       return;
     }
     
@@ -215,6 +226,7 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
 
     stream
       .on('data', (data) => {
+        if (!isCurrent()) return;
         debugLog('[VOICE]', 'Audio data received, target:', data.target);
         
         if (data.target === 'normal') {
@@ -231,6 +243,10 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
         userNode.write(data.buffer);
       })
       .on('end', () => {
+        if (!isCurrent()) {
+          cleanupVoiceStream(streamId);
+          return;
+        }
         debugLog('[VOICE]', 'Voice stream ended for user:', user.username);
         ui.talking.value = 'off';
         

--- a/app/composables/useUserVoiceStream.js
+++ b/app/composables/useUserVoiceStream.js
@@ -89,7 +89,7 @@ export function useUserVoiceStream({ audioStore, voiceStore, settingsStore, self
     // Cleanup runs automatically when watch re-runs or component unmounts
     onWatcherCleanup(() => {
       clearInterval(interval);
-      client.off('dataPing', recalculateJitterBuffer);
+      client.removeListener('dataPing', recalculateJitterBuffer);
     });
   });
 

--- a/app/composables/useVoiceHandler.js
+++ b/app/composables/useVoiceHandler.js
@@ -2,7 +2,6 @@ import {
   ContinuousVoiceHandler,
   PushToTalkVoiceHandler,
   initVoice,
-  onAudioMixerReady,
 } from '../audio/voice';
 import { translate } from '../localize';
 import { debugLog } from '../utils/debug-utils';
@@ -14,12 +13,48 @@ import { debugLog } from '../utils/debug-utils';
  * @param {Function} onMixerReady - Optional callback when audio mixer becomes ready
  */
 export function initVoiceInput(onData, onError, onMixerReady) {
-  initVoice(onData, onError);
+  let settled = false;
+  let resolveReady;
+  let rejectReady;
+  const ready = new Promise((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const stopVoice = initVoice(
+    onData,
+    (error) => {
+      if (!settled) {
+        settled = true;
+        rejectReady(error);
+      }
+      onError(error);
+    },
+    (mixer) => {
+      if (settled) return;
+      try {
+        onMixerReady?.(mixer);
+        settled = true;
+        resolveReady();
+      } catch (error) {
+        settled = true;
+        rejectReady(error);
+        onError(error);
+      }
+    }
+  );
   
-  // Register for mixer ready notification if callback provided
-  if (onMixerReady) {
-    onAudioMixerReady(onMixerReady);
-  }
+  return {
+    ready,
+    stop() {
+      if (!settled) {
+        const error = new Error('Voice capture cancelled');
+        error.code = 'VOICE_CAPTURE_CANCELLED';
+        settled = true;
+        rejectReady(error);
+      }
+      stopVoice?.();
+    },
+  };
 }
 
 /**

--- a/app/index.js
+++ b/app/index.js
@@ -18,6 +18,7 @@ import {
   translate,
 } from "./localize";
 import { resolveConnectAddress } from "./utils/connect-address.js";
+import { clearCredentials } from "./auth/credentials-service.js";
 
 // Check URL parameters for debug-audio flag (used in automated tests)
 const urlParams = new URLSearchParams(globalThis.location.search);
@@ -174,6 +175,9 @@ function applyQueryParamsToConnectDialog() {
  * Handle successful login event
  */
 function handleAuthLogin(user) {
+  // A login can replace an existing Identity session. Do not reuse
+  // credentials that were fetched with the previous token.
+  clearCredentials();
   const username = getUsernameFromMetadata(user);
   if (username) {
     dialogStore.connectDialog.username = username;
@@ -190,7 +194,12 @@ function handleAuthClose() {
   if (widgetHandlingToken) {
     widgetHandlingToken = false;
   }
-  if (dialogStore.connectDialog.username) {
+  const currentUser = auth.currentUser();
+  if (currentUser) {
+    const username = getUsernameFromMetadata(currentUser);
+    if (username) {
+      dialogStore.connectDialog.username = username;
+    }
     // Show connect dialog when auth modal is closed and user is authenticated
     dialogStore.connectDialog.visible = true;
   } else {

--- a/app/index.js
+++ b/app/index.js
@@ -21,6 +21,7 @@ import {
 import { resolveConnectAddress } from "./utils/connect-address.js";
 import { clearCredentials } from "./auth/credentials-service.js";
 import { invalidateConnectionAttempt } from "./composables/connectionAttempt.js";
+import { shouldHandleProviderLogout } from "./composables/useAuthLogout.js";
 
 // Check URL parameters for debug-audio flag (used in automated tests)
 const urlParams = new URLSearchParams(globalThis.location.search);
@@ -208,6 +209,7 @@ function handleAuthLogin(user) {
 }
 
 function handleAuthLogout() {
+  if (!shouldHandleProviderLogout()) return;
   clearCredentials();
   resetAuthenticatedConnection();
   dialogStore.resetAll();

--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,7 @@ import { useVoiceStore } from "./stores/voiceStore";
 import { useUIStore } from "./stores/uiStore";
 import { useDialogStore } from "./stores/dialogStore";
 import { useSettingsStore } from "./stores/settingsStore";
+import { useConnectionStore } from "./stores/connectionStore";
 
 import {
   enumMicrophones,
@@ -19,6 +20,7 @@ import {
 } from "./localize";
 import { resolveConnectAddress } from "./utils/connect-address.js";
 import { clearCredentials } from "./auth/credentials-service.js";
+import { invalidateConnectionAttempt } from "./composables/connectionAttempt.js";
 
 // Check URL parameters for debug-audio flag (used in automated tests)
 const urlParams = new URLSearchParams(globalThis.location.search);
@@ -66,6 +68,7 @@ const voiceStore = useVoiceStore();
 const uiStore = useUIStore();
 const dialogStore = useDialogStore();
 const settingsStore = useSettingsStore();
+const connectionStore = useConnectionStore();
 
 // Initialize settings with config defaults
 settingsStore.initWithDefaults(globalThis.mumbleWebConfig.settings);
@@ -75,6 +78,7 @@ settingsStore.initWithDefaults(globalThis.mumbleWebConfig.settings);
 // is true — the widget fires spurious errors (e.g. 404 from /.netlify/identity/)
 // that would otherwise show the connect dialog on top of the password-reset form.
 let widgetHandlingToken = false;
+let authSessionGeneration = 0;
 
 // Initialize auth - always use Netlify Identity in production
 const authConfig = globalThis.mumbleWebConfig?.auth || { provider: 'netlify' };
@@ -174,27 +178,63 @@ function applyQueryParamsToConnectDialog() {
 /**
  * Handle successful login event
  */
+function resetAuthenticatedConnection() {
+  authSessionGeneration += 1;
+  invalidateConnectionAttempt();
+  uiStore.guacamoleFrame?.stop?.();
+  audioStore.stopBeep();
+  voiceStore.reset();
+  userStore.reset();
+  connectionStore.disconnect();
+  dialogStore.connectDialog.isTestActive = false;
+  uiStore.reset();
+}
+
 function handleAuthLogin(user) {
   // A login can replace an existing Identity session. Do not reuse
   // credentials that were fetched with the previous token.
   clearCredentials();
+  resetAuthenticatedConnection();
+  dialogStore.resetErrorDialog();
+  dialogStore.resetInfoDialog();
+  dialogStore.resetSampleRateDialog();
   const username = getUsernameFromMetadata(user);
   if (username) {
     dialogStore.connectDialog.username = username;
   }
-  auth.close();
+  auth.closeAuth();
   // Show connect dialog after successful authentication
   dialogStore.connectDialog.visible = true;
+}
+
+function handleAuthLogout() {
+  clearCredentials();
+  resetAuthenticatedConnection();
+  dialogStore.resetAll();
 }
 
 /**
  * Handle auth modal close event
  */
-function handleAuthClose() {
+async function handleAuthClose() {
   if (widgetHandlingToken) {
     widgetHandlingToken = false;
   }
-  const currentUser = auth.currentUser();
+  const sessionGeneration = authSessionGeneration;
+  let currentUser;
+  try {
+    currentUser = await auth.getCurrentUser();
+  } catch (error) {
+    if (sessionGeneration !== authSessionGeneration) return;
+    console.warn('[Auth] Failed to read session after closing authentication:', error);
+    try {
+      await auth.openAuth('login');
+    } catch (openError) {
+      console.warn('[Auth] Failed to reopen authentication:', openError);
+    }
+    return;
+  }
+  if (sessionGeneration !== authSessionGeneration) return;
   if (currentUser) {
     const username = getUsernameFromMetadata(currentUser);
     if (username) {
@@ -203,7 +243,7 @@ function handleAuthClose() {
     // Show connect dialog when auth modal is closed and user is authenticated
     dialogStore.connectDialog.visible = true;
   } else {
-    auth.open("login"); // open the modal to the login tab
+    auth.openAuth("login"); // open the modal to the login tab
   }
 }
 
@@ -232,6 +272,7 @@ function hasIdentityTokenInHash() {
  * Initialize authentication and handle initial user state
  */
 async function initializeAuth() {
+  const sessionGeneration = authSessionGeneration;
   let user = null;
   let initSucceeded = false;
 
@@ -241,12 +282,14 @@ async function initializeAuth() {
   const hadIdentityToken = hasIdentityTokenInHash();
 
   try {
-    await auth.init(globalThis.mumbleWebConfig.auth.netlify);
+    await auth.init(authConfig);
     initSucceeded = true;
-    user = auth.currentUser();
+    user = await auth.getCurrentUser();
   } catch (e) {
     console.warn('[Auth] Initialization failed; continuing without authentication', e);
   }
+
+  if (sessionGeneration !== authSessionGeneration) return;
 
   if (initSucceeded && hadIdentityToken) {
     // A recovery/confirmation/invite token is present — let the widget handle
@@ -262,7 +305,7 @@ async function initializeAuth() {
   } else if (user === null) {
     // Hide connect dialog when showing authentication modal
     dialogStore.connectDialog.visible = false;
-    auth.open("login");
+    auth.openAuth("login");
   } else {
     const username = getUsernameFromMetadata(user);
     if (username) {
@@ -278,6 +321,7 @@ function initializeUI() {
 
   // Register event handlers BEFORE init() so they catch auto-login events
   auth.on("login", handleAuthLogin);
+  auth.on("logout", handleAuthLogout);
   auth.on("close", handleAuthClose);
   auth.on("error", handleAuthError);
 

--- a/app/mumble-streams/mumble-proto-minimal.js
+++ b/app/mumble-streams/mumble-proto-minimal.js
@@ -50,7 +50,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Version.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         Version.decode = function (reader, length, _end, _depth, _target) {
@@ -223,7 +223,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UDPTunnel.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         UDPTunnel.decode = function (reader, length, _end, _depth, _target) {
@@ -380,7 +380,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Authenticate.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         Authenticate.decode = function (reader, length, _end, _depth, _target) {
@@ -424,7 +424,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.celtVersions && message.celtVersions.length))
                                 message.celtVersions = [];
-                            reader.int32s(message.celtVersions);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.celtVersions.push(reader.int32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -634,7 +636,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Ping.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         Ping.decode = function (reader, length, _end, _depth, _target) {
@@ -925,7 +927,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Reject.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         Reject.decode = function (reader, length, _end, _depth, _target) {
@@ -1149,7 +1151,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ServerSync.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ServerSync.decode = function (reader, length, _end, _depth, _target) {
@@ -1338,7 +1340,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ChannelRemove.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ChannelRemove.decode = function (reader, length, _end, _depth, _target) {
@@ -1506,7 +1508,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ChannelState.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ChannelState.decode = function (reader, length, _end, _depth, _target) {
@@ -1548,7 +1550,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.links && message.links.length))
                                 message.links = [];
-                            reader.uint32s(message.links);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.links.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -1568,7 +1572,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.linksAdd && message.linksAdd.length))
                                 message.linksAdd = [];
-                            reader.uint32s(message.linksAdd);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.linksAdd.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -1582,7 +1588,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.linksRemove && message.linksRemove.length))
                                 message.linksRemove = [];
-                            reader.uint32s(message.linksRemove);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.linksRemove.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -1857,7 +1865,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserRemove.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         UserRemove.decode = function (reader, length, _end, _depth, _target) {
@@ -2086,7 +2094,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserState.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         UserState.decode = function (reader, length, _end, _depth, _target) {
@@ -2511,7 +2519,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         BanList.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         BanList.decode = function (reader, length, _end, _depth, _target) {
@@ -2689,7 +2697,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             BanEntry.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             BanEntry.decode = function (reader, length, _end, _depth, _target) {
@@ -2936,7 +2944,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         TextMessage.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         TextMessage.decode = function (reader, length, _end, _depth, _target) {
@@ -2966,7 +2974,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.session && message.session.length))
                                 message.session = [];
-                            reader.uint32s(message.session);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.session.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -2980,7 +2990,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.channelId && message.channelId.length))
                                 message.channelId = [];
-                            reader.uint32s(message.channelId);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.channelId.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -2994,7 +3006,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.treeId && message.treeId.length))
                                 message.treeId = [];
-                            reader.uint32s(message.treeId);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.treeId.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -3202,7 +3216,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         PermissionDenied.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         PermissionDenied.decode = function (reader, length, _end, _depth, _target) {
@@ -3500,7 +3514,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ACL.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ACL.decode = function (reader, length, _end, _depth, _target) {
@@ -3749,7 +3763,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             ChanGroup.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             ChanGroup.decode = function (reader, length, _end, _depth, _target) {
@@ -3797,7 +3811,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.add && message.add.length))
                                     message.add = [];
-                                reader.uint32s(message.add);
+                                let end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.add.push(reader.uint32());
                                 continue;
                             }
                             if (wireType !== 0)
@@ -3811,7 +3827,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.remove && message.remove.length))
                                     message.remove = [];
-                                reader.uint32s(message.remove);
+                                let end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.remove.push(reader.uint32());
                                 continue;
                             }
                             if (wireType !== 0)
@@ -3825,7 +3843,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.inheritedMembers && message.inheritedMembers.length))
                                     message.inheritedMembers = [];
-                                reader.uint32s(message.inheritedMembers);
+                                let end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.inheritedMembers.push(reader.uint32());
                                 continue;
                             }
                             if (wireType !== 0)
@@ -4046,7 +4066,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             ChanACL.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             ChanACL.decode = function (reader, length, _end, _depth, _target) {
@@ -4272,7 +4292,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         QueryUsers.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         QueryUsers.decode = function (reader, length, _end, _depth, _target) {
@@ -4296,7 +4316,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.ids && message.ids.length))
                                 message.ids = [];
-                            reader.uint32s(message.ids);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.ids.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -4458,7 +4480,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         CryptSetup.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         CryptSetup.decode = function (reader, length, _end, _depth, _target) {
@@ -4653,7 +4675,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ContextActionModify.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ContextActionModify.decode = function (reader, length, _end, _depth, _target) {
@@ -4868,7 +4890,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ContextAction.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ContextAction.decode = function (reader, length, _end, _depth, _target) {
@@ -5031,7 +5053,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserList.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         UserList.decode = function (reader, length, _end, _depth, _target) {
@@ -5186,7 +5208,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             User.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             User.decode = function (reader, length, _end, _depth, _target) {
@@ -5369,7 +5391,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         VoiceTarget.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         VoiceTarget.decode = function (reader, length, _end, _depth, _target) {
@@ -5545,7 +5567,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             Target.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             Target.decode = function (reader, length, _end, _depth, _target) {
@@ -5569,7 +5591,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.session && message.session.length))
                                     message.session = [];
-                                reader.uint32s(message.session);
+                                let end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.session.push(reader.uint32());
                                 continue;
                             }
                             if (wireType !== 0)
@@ -5763,7 +5787,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         PermissionQuery.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         PermissionQuery.decode = function (reader, length, _end, _depth, _target) {
@@ -5929,7 +5953,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         CodecVersion.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         CodecVersion.decode = function (reader, length, _end, _depth, _target) {
@@ -6164,7 +6188,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserStats.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         UserStats.decode = function (reader, length, _end, _depth, _target) {
@@ -6262,7 +6286,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.celtVersions && message.celtVersions.length))
                                 message.celtVersions = [];
-                            reader.int32s(message.celtVersions);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.celtVersions.push(reader.int32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -6617,7 +6643,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             Stats.encodeDelimited = function(message, writer) {
-                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
             };
 
             Stats.decode = function (reader, length, _end, _depth, _target) {
@@ -6806,7 +6832,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         RequestBlob.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         RequestBlob.decode = function (reader, length, _end, _depth, _target) {
@@ -6830,7 +6856,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.sessionTexture && message.sessionTexture.length))
                                 message.sessionTexture = [];
-                            reader.uint32s(message.sessionTexture);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.sessionTexture.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -6844,7 +6872,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.sessionComment && message.sessionComment.length))
                                 message.sessionComment = [];
-                            reader.uint32s(message.sessionComment);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.sessionComment.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -6858,7 +6888,9 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.channelDescription && message.channelDescription.length))
                                 message.channelDescription = [];
-                            reader.uint32s(message.channelDescription);
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.channelDescription.push(reader.uint32());
                             continue;
                         }
                         if (wireType !== 0)
@@ -7041,7 +7073,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ServerConfig.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         ServerConfig.decode = function (reader, length, _end, _depth, _target) {
@@ -7249,7 +7281,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         SuggestConfig.encodeDelimited = function(message, writer) {
-            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
+            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
         };
 
         SuggestConfig.decode = function (reader, length, _end, _depth, _target) {

--- a/app/mumble-streams/mumble-proto-minimal.js
+++ b/app/mumble-streams/mumble-proto-minimal.js
@@ -50,7 +50,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Version.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         Version.decode = function (reader, length, _end, _depth, _target) {
@@ -223,7 +223,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UDPTunnel.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         UDPTunnel.decode = function (reader, length, _end, _depth, _target) {
@@ -380,7 +380,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Authenticate.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         Authenticate.decode = function (reader, length, _end, _depth, _target) {
@@ -424,9 +424,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.celtVersions && message.celtVersions.length))
                                 message.celtVersions = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.celtVersions.push(reader.int32());
+                            reader.int32s(message.celtVersions);
                             continue;
                         }
                         if (wireType !== 0)
@@ -636,7 +634,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Ping.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         Ping.decode = function (reader, length, _end, _depth, _target) {
@@ -927,7 +925,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         Reject.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         Reject.decode = function (reader, length, _end, _depth, _target) {
@@ -1151,7 +1149,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ServerSync.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ServerSync.decode = function (reader, length, _end, _depth, _target) {
@@ -1340,7 +1338,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ChannelRemove.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ChannelRemove.decode = function (reader, length, _end, _depth, _target) {
@@ -1508,7 +1506,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ChannelState.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ChannelState.decode = function (reader, length, _end, _depth, _target) {
@@ -1550,9 +1548,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.links && message.links.length))
                                 message.links = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.links.push(reader.uint32());
+                            reader.uint32s(message.links);
                             continue;
                         }
                         if (wireType !== 0)
@@ -1572,9 +1568,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.linksAdd && message.linksAdd.length))
                                 message.linksAdd = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.linksAdd.push(reader.uint32());
+                            reader.uint32s(message.linksAdd);
                             continue;
                         }
                         if (wireType !== 0)
@@ -1588,9 +1582,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.linksRemove && message.linksRemove.length))
                                 message.linksRemove = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.linksRemove.push(reader.uint32());
+                            reader.uint32s(message.linksRemove);
                             continue;
                         }
                         if (wireType !== 0)
@@ -1865,7 +1857,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserRemove.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         UserRemove.decode = function (reader, length, _end, _depth, _target) {
@@ -2094,7 +2086,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserState.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         UserState.decode = function (reader, length, _end, _depth, _target) {
@@ -2519,7 +2511,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         BanList.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         BanList.decode = function (reader, length, _end, _depth, _target) {
@@ -2697,7 +2689,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             BanEntry.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             BanEntry.decode = function (reader, length, _end, _depth, _target) {
@@ -2944,7 +2936,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         TextMessage.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         TextMessage.decode = function (reader, length, _end, _depth, _target) {
@@ -2974,9 +2966,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.session && message.session.length))
                                 message.session = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.session.push(reader.uint32());
+                            reader.uint32s(message.session);
                             continue;
                         }
                         if (wireType !== 0)
@@ -2990,9 +2980,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.channelId && message.channelId.length))
                                 message.channelId = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.channelId.push(reader.uint32());
+                            reader.uint32s(message.channelId);
                             continue;
                         }
                         if (wireType !== 0)
@@ -3006,9 +2994,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.treeId && message.treeId.length))
                                 message.treeId = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.treeId.push(reader.uint32());
+                            reader.uint32s(message.treeId);
                             continue;
                         }
                         if (wireType !== 0)
@@ -3216,7 +3202,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         PermissionDenied.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         PermissionDenied.decode = function (reader, length, _end, _depth, _target) {
@@ -3514,7 +3500,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ACL.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ACL.decode = function (reader, length, _end, _depth, _target) {
@@ -3763,7 +3749,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             ChanGroup.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             ChanGroup.decode = function (reader, length, _end, _depth, _target) {
@@ -3811,9 +3797,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.add && message.add.length))
                                     message.add = [];
-                                let end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
-                                    message.add.push(reader.uint32());
+                                reader.uint32s(message.add);
                                 continue;
                             }
                             if (wireType !== 0)
@@ -3827,9 +3811,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.remove && message.remove.length))
                                     message.remove = [];
-                                let end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
-                                    message.remove.push(reader.uint32());
+                                reader.uint32s(message.remove);
                                 continue;
                             }
                             if (wireType !== 0)
@@ -3843,9 +3825,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.inheritedMembers && message.inheritedMembers.length))
                                     message.inheritedMembers = [];
-                                let end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
-                                    message.inheritedMembers.push(reader.uint32());
+                                reader.uint32s(message.inheritedMembers);
                                 continue;
                             }
                             if (wireType !== 0)
@@ -4066,7 +4046,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             ChanACL.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             ChanACL.decode = function (reader, length, _end, _depth, _target) {
@@ -4292,7 +4272,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         QueryUsers.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         QueryUsers.decode = function (reader, length, _end, _depth, _target) {
@@ -4316,9 +4296,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.ids && message.ids.length))
                                 message.ids = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.ids.push(reader.uint32());
+                            reader.uint32s(message.ids);
                             continue;
                         }
                         if (wireType !== 0)
@@ -4480,7 +4458,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         CryptSetup.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         CryptSetup.decode = function (reader, length, _end, _depth, _target) {
@@ -4675,7 +4653,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ContextActionModify.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ContextActionModify.decode = function (reader, length, _end, _depth, _target) {
@@ -4890,7 +4868,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ContextAction.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ContextAction.decode = function (reader, length, _end, _depth, _target) {
@@ -5053,7 +5031,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserList.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         UserList.decode = function (reader, length, _end, _depth, _target) {
@@ -5208,7 +5186,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             User.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             User.decode = function (reader, length, _end, _depth, _target) {
@@ -5391,7 +5369,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         VoiceTarget.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         VoiceTarget.decode = function (reader, length, _end, _depth, _target) {
@@ -5567,7 +5545,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             Target.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             Target.decode = function (reader, length, _end, _depth, _target) {
@@ -5591,9 +5569,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                             if (wireType === 2) {
                                 if (!(message.session && message.session.length))
                                     message.session = [];
-                                let end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
-                                    message.session.push(reader.uint32());
+                                reader.uint32s(message.session);
                                 continue;
                             }
                             if (wireType !== 0)
@@ -5787,7 +5763,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         PermissionQuery.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         PermissionQuery.decode = function (reader, length, _end, _depth, _target) {
@@ -5953,7 +5929,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         CodecVersion.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         CodecVersion.decode = function (reader, length, _end, _depth, _target) {
@@ -6188,7 +6164,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         UserStats.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         UserStats.decode = function (reader, length, _end, _depth, _target) {
@@ -6286,9 +6262,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.celtVersions && message.celtVersions.length))
                                 message.celtVersions = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.celtVersions.push(reader.int32());
+                            reader.int32s(message.celtVersions);
                             continue;
                         }
                         if (wireType !== 0)
@@ -6643,7 +6617,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
             };
 
             Stats.encodeDelimited = function(message, writer) {
-                return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+                return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
             };
 
             Stats.decode = function (reader, length, _end, _depth, _target) {
@@ -6832,7 +6806,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         RequestBlob.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         RequestBlob.decode = function (reader, length, _end, _depth, _target) {
@@ -6856,9 +6830,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.sessionTexture && message.sessionTexture.length))
                                 message.sessionTexture = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.sessionTexture.push(reader.uint32());
+                            reader.uint32s(message.sessionTexture);
                             continue;
                         }
                         if (wireType !== 0)
@@ -6872,9 +6844,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.sessionComment && message.sessionComment.length))
                                 message.sessionComment = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.sessionComment.push(reader.uint32());
+                            reader.uint32s(message.sessionComment);
                             continue;
                         }
                         if (wireType !== 0)
@@ -6888,9 +6858,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
                         if (wireType === 2) {
                             if (!(message.channelDescription && message.channelDescription.length))
                                 message.channelDescription = [];
-                            let end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
-                                message.channelDescription.push(reader.uint32());
+                            reader.uint32s(message.channelDescription);
                             continue;
                         }
                         if (wireType !== 0)
@@ -7073,7 +7041,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         ServerConfig.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         ServerConfig.decode = function (reader, length, _end, _depth, _target) {
@@ -7281,7 +7249,7 @@ export const MumbleProto = $root.MumbleProto = (() => {
         };
 
         SuggestConfig.encodeDelimited = function(message, writer) {
-            return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+            return this.encode(message, (writer || $Writer.create()).fork()).ldelim();
         };
 
         SuggestConfig.decode = function (reader, length, _end, _depth, _target) {

--- a/app/mumble-websocket.js
+++ b/app/mumble-websocket.js
@@ -1,11 +1,39 @@
 import websocketStream from "./utils/websocket-stream-lite.js";
 import MumbleClient from "./mumble-client/index.js";
 
-async function connect(address, options) {
+async function connect(address, options, { signal } = {}) {
+  if (signal?.aborted) {
+    throw new DOMException("Connection aborted", "AbortError");
+  }
+
+  let pendingStream;
   const ws = await new Promise((resolve, reject) => {
-    const ws = websocketStream(address, ["binary"])
-      .on("error", reject)
-      .on("connect", () => resolve(ws));
+    let settled = false;
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      pendingStream.destroy();
+      reject(new DOMException("Connection aborted", "AbortError"));
+    };
+    const onError = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onConnect = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(pendingStream);
+    };
+
+    pendingStream = websocketStream(address, ["binary"])
+      .once("error", onError)
+      .once("connect", onConnect);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
   return new MumbleClient(options).connectDataStream(ws);
 }

--- a/app/mumble-websocket.js
+++ b/app/mumble-websocket.js
@@ -7,15 +7,20 @@ async function connect(address, options, { signal } = {}) {
   }
 
   let pendingStream;
-  const ws = await new Promise((resolve, reject) => {
+  const abortError = () => new DOMException("Connection aborted", "AbortError");
+  const handshake = new Promise((resolve, reject) => {
     let settled = false;
-    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const cleanup = () => {
+      signal?.removeEventListener("abort", onAbort);
+      pendingStream?.removeListener("error", onError);
+      pendingStream?.removeListener("connect", onConnect);
+    };
     const onAbort = () => {
       if (settled) return;
       settled = true;
       cleanup();
       pendingStream.destroy();
-      reject(new DOMException("Connection aborted", "AbortError"));
+      reject(abortError());
     };
     const onError = (error) => {
       if (settled) return;
@@ -25,9 +30,31 @@ async function connect(address, options, { signal } = {}) {
     };
     const onConnect = () => {
       if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(pendingStream);
+      let connection;
+      try {
+        connection = new MumbleClient(options).connectDataStream(pendingStream);
+      } catch (error) {
+        settled = true;
+        cleanup();
+        pendingStream.destroy();
+        reject(error);
+        return;
+      }
+      connection.then(
+        (client) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve(client);
+        },
+        (error) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          pendingStream.destroy();
+          reject(error);
+        }
+      );
     };
 
     pendingStream = websocketStream(address, ["binary"])
@@ -35,7 +62,7 @@ async function connect(address, options, { signal } = {}) {
       .once("connect", onConnect);
     signal?.addEventListener("abort", onAbort, { once: true });
   });
-  return new MumbleClient(options).connectDataStream(ws);
+  return handshake;
 }
 
 export default connect;

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -24,8 +24,12 @@ export const useAudioStore = defineStore('audio', () => {
   const beeperReady = ref(false);
   let _persistentBeeper = null;
   let _persistentBeeperMixer = null;
+  let beeperGeneration = 0;
+  let beeperInitialization = null;
 
   function resetBeeper() {
+    beeperGeneration += 1;
+    beeperInitialization = null;
     const beeper = _persistentBeeper;
     if (!beeper) {
       beeperReady.value = false;
@@ -159,45 +163,37 @@ export const useAudioStore = defineStore('audio', () => {
     micPermissionErrorMessage.value = '';
   }
 
-  /**
-   * Initialize persistent beeper for latency testing
-   * 
-   * EVENT-BASED: No timeouts! This method is called when audio mixer becomes available.
-   * RACE-SAFE: Multiple concurrent calls will reuse the same initialization.
-   */
-  const createPersistentBeeper = createCachedInitWithCheck(
-    () => null,
-    async (mixer) => {
-      // Check if mixer is available NOW (no waiting, no timeout)
-      if (!mixer) {
-        debugLog('[BEEP]', 'Mixer not yet available, will retry when mixer is ready');
-        beeperReady.value = false;
-        return null;
-      }
-      
-      const ac = await globalThis.audioContextManager.getAudioContext();
-      if (!ac) {
-        debugLog('[BEEP]', 'AudioContext not available');
-        beeperReady.value = false;
-        return null;
-      }
-      
-      // AUTOPLAY-POLICY: Allow beeper initialization even when AudioContext is suspended
-      // The Piano button click will resume the context via user gesture
-      // Only block if context is closed or in an error state
-      if (ac.state === 'closed') {
-        debugLog('[BEEP]', 'AudioContext is closed', { state: ac.state });
-        beeperReady.value = false;
-        return null;
-      }
-      
-      debugLog('[BEEP]', 'Initializing persistent beeper...', { state: ac.state });
-      
-      try {
-        // Create permanent oscillator with split output for local+remote playback
-        const oscillator = ac.createOscillator();
-        const beepGain = ac.createGain();
-        const localGain = ac.createGain();
+  async function createPersistentBeeper(mixer, generation) {
+    // Check if mixer is available NOW (no waiting, no timeout)
+    if (!mixer) {
+      debugLog('[BEEP]', 'Mixer not yet available, will retry when mixer is ready');
+      beeperReady.value = false;
+      return null;
+    }
+    const ac = await globalThis.audioContextManager.getAudioContext();
+    if (generation !== beeperGeneration) return null;
+    if (!ac) {
+      debugLog('[BEEP]', 'AudioContext not available');
+      beeperReady.value = false;
+      return null;
+    }
+
+    // AUTOPLAY-POLICY: Allow beeper initialization even when AudioContext is suspended
+    // The Piano button click will resume the context via user gesture
+    // Only block if context is closed or in an error state
+    if (ac.state === 'closed') {
+      debugLog('[BEEP]', 'AudioContext is closed', { state: ac.state });
+      beeperReady.value = false;
+      return null;
+    }
+
+    debugLog('[BEEP]', 'Initializing persistent beeper...', { state: ac.state });
+
+    try {
+      // Create permanent oscillator with split output for local+remote playback
+      const oscillator = ac.createOscillator();
+      const beepGain = ac.createGain();
+      const localGain = ac.createGain();
         
         oscillator.frequency.setValueAtTime(440, ac.currentTime);
         oscillator.type = 'sine';
@@ -212,6 +208,14 @@ export const useAudioStore = defineStore('audio', () => {
         localGain.connect(ac.destination);
         
         oscillator.start();
+
+        if (generation !== beeperGeneration) {
+          oscillator.stop();
+          oscillator.disconnect();
+          beepGain.disconnect();
+          localGain.disconnect();
+          return null;
+        }
         
         _persistentBeeper = {
           oscillator,
@@ -223,13 +227,12 @@ export const useAudioStore = defineStore('audio', () => {
         
         beeperReady.value = true;
         return _persistentBeeper;
-      } catch (err) {
-        console.error('[BEEP] Failed to initialize persistent beeper:', err);
-        beeperReady.value = false;
-        return null;
-      }
+    } catch (err) {
+      console.error('[BEEP] Failed to initialize persistent beeper:', err);
+      beeperReady.value = false;
+      return null;
     }
-  );
+  }
 
   async function initializePersistentBeeper() {
     const mixer = getCurrentMixer();
@@ -237,7 +240,14 @@ export const useAudioStore = defineStore('audio', () => {
       resetBeeper();
     }
     if (_persistentBeeper) return _persistentBeeper;
-    return createPersistentBeeper(mixer);
+
+    if (beeperInitialization?.mixer === mixer) return beeperInitialization.promise;
+    const generation = ++beeperGeneration;
+    const promise = createPersistentBeeper(mixer, generation).finally(() => {
+      if (beeperInitialization?.generation === generation) beeperInitialization = null;
+    });
+    beeperInitialization = { mixer, generation, promise };
+    return promise;
   }
 
   /**

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -73,6 +73,7 @@ export const useAudioStore = defineStore('audio', () => {
           audioContext.value = new AudioContextClass({ latencyHint: 'interactive' });
         } catch (fallbackError) {
           console.error('Both managed and legacy AudioContext initialization failed:', fallbackError);
+          throw fallbackError;
         }
       }
       

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -267,6 +267,7 @@ export const useAudioStore = defineStore('audio', () => {
     
     try {
       const beeper = _persistentBeeper;
+      const generation = beeperGeneration;
       const ac = beeper.gain.context;
       
       // AUTOPLAY-POLICY: Resume AudioContext if suspended (Piano button = user gesture)
@@ -275,6 +276,8 @@ export const useAudioStore = defineStore('audio', () => {
         await ac.resume();
         debugLog('[BEEP]', 'AudioContext resumed:', { state: ac.state });
       }
+
+      if (generation !== beeperGeneration || _persistentBeeper !== beeper) return;
       
       const currentTime = ac.currentTime;
       const attackTime = 0.005;

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -85,11 +85,10 @@ export const useAudioStore = defineStore('audio', () => {
    * Resume AudioContext if suspended
    */
   async function resumeAudioContext() {
-    if (audioContext.value?.state === 'suspended') {
-      await audioContext.value.resume();
-    } else if (!audioContext.value) {
+    if (!audioContext.value) {
       await initializeAudioContext();
     }
+    await audioContextManager.resumeAudioContext();
   }
 
   /**

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -23,6 +23,28 @@ export const useAudioStore = defineStore('audio', () => {
   const isBeeping = ref(false);
   const beeperReady = ref(false);
   let _persistentBeeper = null;
+  let _persistentBeeperMixer = null;
+
+  function resetBeeper() {
+    const beeper = _persistentBeeper;
+    if (!beeper) {
+      beeperReady.value = false;
+      isBeeping.value = false;
+      return;
+    }
+    try {
+      beeper.oscillator.stop?.();
+    } catch (error) {
+      debugLog('[BEEP]', 'Persistent beeper was already stopped:', error);
+    }
+    for (const node of [beeper.oscillator, beeper.gain, beeper.localGain]) {
+      node?.disconnect?.();
+    }
+    _persistentBeeper = null;
+    _persistentBeeperMixer = null;
+    isBeeping.value = false;
+    beeperReady.value = false;
+  }
 
   // SYNC-WITH-MANAGER: Ensure store stays in sync with AudioContextManager singleton
   // This handles cases where AudioContext is initialized by other modules (e.g. voice.js)
@@ -143,11 +165,10 @@ export const useAudioStore = defineStore('audio', () => {
    * EVENT-BASED: No timeouts! This method is called when audio mixer becomes available.
    * RACE-SAFE: Multiple concurrent calls will reuse the same initialization.
    */
-  const initializePersistentBeeper = createCachedInitWithCheck(
-    () => _persistentBeeper,
-    async () => {
+  const createPersistentBeeper = createCachedInitWithCheck(
+    () => null,
+    async (mixer) => {
       // Check if mixer is available NOW (no waiting, no timeout)
-      const mixer = getCurrentMixer();
       if (!mixer) {
         debugLog('[BEEP]', 'Mixer not yet available, will retry when mixer is ready');
         beeperReady.value = false;
@@ -198,6 +219,7 @@ export const useAudioStore = defineStore('audio', () => {
           localGain: localGain,
           isPlaying: false
         };
+        _persistentBeeperMixer = mixer;
         
         beeperReady.value = true;
         return _persistentBeeper;
@@ -208,6 +230,15 @@ export const useAudioStore = defineStore('audio', () => {
       }
     }
   );
+
+  async function initializePersistentBeeper() {
+    const mixer = getCurrentMixer();
+    if (_persistentBeeper && _persistentBeeperMixer !== mixer) {
+      resetBeeper();
+    }
+    if (_persistentBeeper) return _persistentBeeper;
+    return createPersistentBeeper(mixer);
+  }
 
   /**
    * Start beeping
@@ -329,6 +360,7 @@ export const useAudioStore = defineStore('audio', () => {
     loadAudioWorkletModule,
     startBeep,
     stopBeep,
+    resetBeeper,
     initializePersistentBeeper,
     retryMicrophonePermission,
     notifyAudioLock,

--- a/app/stores/audioStore.js
+++ b/app/stores/audioStore.js
@@ -63,18 +63,7 @@ export const useAudioStore = defineStore('audio', () => {
 
       } catch (error) {
         console.error('Failed to initialize AudioContext:', error);
-        
-        // Fallback: Try legacy AudioContext creation
-        try {
-          const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
-          if (!AudioContextClass) {
-            throw new Error('AudioContext is not supported in this browser');
-          }
-          audioContext.value = new AudioContextClass({ latencyHint: 'interactive' });
-        } catch (fallbackError) {
-          console.error('Both managed and legacy AudioContext initialization failed:', fallbackError);
-          throw fallbackError;
-        }
+        throw error;
       }
       
       return audioContext.value;

--- a/app/stores/connectionStore.js
+++ b/app/stores/connectionStore.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { ref, shallowRef, computed } from 'vue';
+import { ref, shallowRef, computed, toRaw } from 'vue';
 import { translate } from '../localize';
 import { buildWebSocketUrl } from '../utils/websocket-url';
 
@@ -90,7 +90,7 @@ export const useConnectionStore = defineStore('connection', () => {
       const newClient = await conn.connect(wsUrl, {
         username: username,
         password: password,
-        tokens: tokens,
+        tokens: toRaw(tokens),
       }, {
         signal: controller.signal,
       });

--- a/app/stores/connectionStore.js
+++ b/app/stores/connectionStore.js
@@ -8,6 +8,7 @@ export const useConnectionStore = defineStore('connection', () => {
   
   // Lazy-loaded connector - only created when first connection is made
   let _connector = null;
+  let connectorInitialization = null;
   const connector = shallowRef(null);
   const client = shallowRef(null);
   let connectionGeneration = 0;
@@ -27,9 +28,12 @@ export const useConnectionStore = defineStore('connection', () => {
    */
   async function getConnector() {
     if (!_connector) {
-      const { default: WorkerBasedMumbleConnector } = await import('../worker-client');
-      _connector = new WorkerBasedMumbleConnector();
-      connector.value = _connector;
+      connectorInitialization ??= import('../worker-client').then(({ default: WorkerBasedMumbleConnector }) => {
+        _connector = new WorkerBasedMumbleConnector();
+        connector.value = _connector;
+        return _connector;
+      });
+      await connectorInitialization;
     }
     return _connector;
   }

--- a/app/stores/connectionStore.js
+++ b/app/stores/connectionStore.js
@@ -10,6 +10,15 @@ export const useConnectionStore = defineStore('connection', () => {
   let _connector = null;
   const connector = shallowRef(null);
   const client = shallowRef(null);
+  let connectionGeneration = 0;
+
+  class SupersededConnectionAttemptError extends Error {
+    constructor() {
+      super('Connection attempt superseded');
+      this.name = 'SupersededConnectionAttemptError';
+      this.code = 'CONNECTION_ATTEMPT_SUPERSEDED';
+    }
+  }
   
   /**
    * Get or create the WorkerBasedMumbleConnector (lazy initialization)
@@ -46,6 +55,8 @@ export const useConnectionStore = defineStore('connection', () => {
    * @returns {Promise<MumbleClient>} Connected client instance
    */
   async function connect(host, port, username, password, tokens = []) {
+    const generation = ++connectionGeneration;
+
     // Disconnect existing client before creating new connection
     if (client.value) {
       client.value.disconnect();
@@ -69,13 +80,20 @@ export const useConnectionStore = defineStore('connection', () => {
         tokens: tokens,
       });
 
+      if (generation !== connectionGeneration) {
+        newClient.disconnect();
+        throw new SupersededConnectionAttemptError();
+      }
+
       client.value = newClient;
 
       logger(translate('logentry.connected'));
 
       return newClient;
     } catch (err) {
-      logger(translate('logentry.connection_failed'), err);
+      if (err?.code !== 'CONNECTION_ATTEMPT_SUPERSEDED') {
+        logger(translate('logentry.connection_failed'), err);
+      }
       throw err;
     }
   }
@@ -84,6 +102,7 @@ export const useConnectionStore = defineStore('connection', () => {
    * Disconnect from current server
    */
   function disconnect() {
+    connectionGeneration += 1;
     if (client.value) {
       client.value.disconnect();
       client.value = null;

--- a/app/stores/connectionStore.js
+++ b/app/stores/connectionStore.js
@@ -28,11 +28,16 @@ export const useConnectionStore = defineStore('connection', () => {
    */
   async function getConnector() {
     if (!_connector) {
-      connectorInitialization ??= import('../worker-client').then(({ default: WorkerBasedMumbleConnector }) => {
-        _connector = new WorkerBasedMumbleConnector();
-        connector.value = _connector;
-        return _connector;
-      });
+      connectorInitialization ??= import('../worker-client')
+        .then(({ default: WorkerBasedMumbleConnector }) => {
+          _connector = new WorkerBasedMumbleConnector();
+          connector.value = _connector;
+          return _connector;
+        })
+        .catch(error => {
+          connectorInitialization = null;
+          throw error;
+        });
       await connectorInitialization;
     }
     return _connector;

--- a/app/stores/connectionStore.js
+++ b/app/stores/connectionStore.js
@@ -11,6 +11,7 @@ export const useConnectionStore = defineStore('connection', () => {
   const connector = shallowRef(null);
   const client = shallowRef(null);
   let connectionGeneration = 0;
+  let connectionController = null;
 
   class SupersededConnectionAttemptError extends Error {
     constructor() {
@@ -55,6 +56,9 @@ export const useConnectionStore = defineStore('connection', () => {
    * @returns {Promise<MumbleClient>} Connected client instance
    */
   async function connect(host, port, username, password, tokens = []) {
+    connectionController?.abort();
+    const controller = new AbortController();
+    connectionController = controller;
     const generation = ++connectionGeneration;
 
     // Disconnect existing client before creating new connection
@@ -78,6 +82,8 @@ export const useConnectionStore = defineStore('connection', () => {
         username: username,
         password: password,
         tokens: tokens,
+      }, {
+        signal: controller.signal,
       });
 
       if (generation !== connectionGeneration) {
@@ -86,11 +92,18 @@ export const useConnectionStore = defineStore('connection', () => {
       }
 
       client.value = newClient;
+      connectionController = null;
 
       logger(translate('logentry.connected'));
 
       return newClient;
     } catch (err) {
+      if (connectionController === controller) {
+        connectionController = null;
+      }
+      if (controller.signal.aborted && generation !== connectionGeneration) {
+        throw new SupersededConnectionAttemptError();
+      }
       if (err?.code !== 'CONNECTION_ATTEMPT_SUPERSEDED') {
         logger(translate('logentry.connection_failed'), err);
       }
@@ -102,6 +115,8 @@ export const useConnectionStore = defineStore('connection', () => {
    * Disconnect from current server
    */
   function disconnect() {
+    connectionController?.abort();
+    connectionController = null;
     connectionGeneration += 1;
     if (client.value) {
       client.value.disconnect();

--- a/app/stores/dialogStore.js
+++ b/app/stores/dialogStore.js
@@ -28,8 +28,7 @@ export const useDialogStore = defineStore('dialog', () => {
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Connect Error Dialog State
-  // Error types: 0=refused, 1=incompatible, 2=username rejected, 3=user pw wrong,
-  // 4=server pw wrong, 5=username in use, 6=full, 7=NoCert, 8=refused alt
+  // Error types: numeric Mumble Reject types; 'generic' for local setup failures
   // ═══════════════════════════════════════════════════════════════════════════
   const errorDialog = reactive({
     type: 0,
@@ -90,7 +89,7 @@ export const useDialogStore = defineStore('dialog', () => {
   // Error Dialog Actions
   function showErrorDialog(error, _connectionParams) {
     if (error) {
-      errorDialog.type = error.type ?? 0;
+      errorDialog.type = error.type ?? 'generic';
       errorDialog.reason = error.reason ?? error.message ?? '';
     }
     errorDialog.visible = true;

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -165,7 +165,7 @@ export const useUserStore = defineStore('user', () => {
   }
 
   function reset() {
-    for (const user of [...registeredUsers]) unregisterUser(user);
+    for (const user of registeredUsers) unregisterUser(user);
     thisUser.value = null;
     selfMute.value = false;
     selfDeaf.value = false;

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -60,7 +60,7 @@ export const useUserStore = defineStore('user', () => {
     const listeners = user.__uiListeners;
     if (!listeners) return;
     for (const [event, listener] of Object.entries(listeners)) {
-      user.off(event, listener);
+      user.removeListener(event, listener);
     }
     if (user.__uiListeners === listeners) delete user.__uiListeners;
     registeredUsers.delete(user);

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -21,7 +21,7 @@ export const useUserStore = defineStore('user', () => {
   const selfDeaf = ref(false);
   
   // Use extracted voice stream logic
-  const { handleVoiceStream } = useUserVoiceStream({
+  const { handleVoiceStream, cleanupVoiceStream } = useUserVoiceStream({
     audioStore,
     voiceStore,
     settingsStore,
@@ -54,12 +54,27 @@ export const useUserStore = defineStore('user', () => {
    * Register a user with minimal UI wrapper
    * @param {object} user - User model from mumble-client
    */
-  function registerUser(user) {
+  const registeredUsers = new Set();
+
+  function unregisterUser(user) {
+    const listeners = user.__uiListeners;
+    if (!listeners) return;
+    for (const [event, listener] of Object.entries(listeners)) {
+      user.off(event, listener);
+    }
+    if (user.__uiListeners === listeners) delete user.__uiListeners;
+    registeredUsers.delete(user);
+    cleanupVoiceStream(user.session);
+  }
+
+  function registerUser(user, isCurrent = () => true) {
+    unregisterUser(user);
     if (user.__ui) {
       delete user.__ui;
     }
 
     const syncServerState = (serverState) => {
+      if (!isCurrent()) return;
       debugLog('[SERVER-STATE-SYNC] Received server state:', serverState);
       debugLog('[SERVER-STATE-SYNC] Current UI state:', { selfMute: selfMute.value, selfDeaf: selfDeaf.value });
       
@@ -73,13 +88,6 @@ export const useUserStore = defineStore('user', () => {
       debugLog('[SERVER-STATE-SYNC] UI synchronized to:', { selfMute: selfMute.value, selfDeaf: selfDeaf.value });
     };
     
-    if (user.__syncServerState) {
-      user.off('server-state-sync', user.__syncServerState);
-    }
-    
-    user.__syncServerState = syncServerState;
-    user.on('server-state-sync', syncServerState);
-    
     let ui = (user.__ui = markRaw({
       model: user,
       name: ref(user.username),
@@ -89,9 +97,17 @@ export const useUserStore = defineStore('user', () => {
       talking: ref('off'),
     }));
     
-    user.on('update', (actor, properties) => handleUserUpdate(user, ui, properties));
-
-    user.on('voice', (stream) => handleVoiceStream(user, ui, stream));
+    const update = (actor, properties) => {
+      if (isCurrent()) handleUserUpdate(user, ui, properties);
+    };
+    const voice = (stream) => {
+      if (isCurrent()) return handleVoiceStream(user, ui, stream, isCurrent);
+    };
+    user.__uiListeners = { 'server-state-sync': syncServerState, update, voice };
+    registeredUsers.add(user);
+    for (const [event, listener] of Object.entries(user.__uiListeners)) {
+      user.on(event, listener);
+    }
   }
   
   function requestMute(user) {
@@ -149,6 +165,7 @@ export const useUserStore = defineStore('user', () => {
   }
 
   function reset() {
+    for (const user of [...registeredUsers]) unregisterUser(user);
     thisUser.value = null;
     selfMute.value = false;
     selfDeaf.value = false;

--- a/app/stores/voiceStore.js
+++ b/app/stores/voiceStore.js
@@ -28,6 +28,7 @@ export const useVoiceStore = defineStore('voice', () => {
   function stopVoiceCapture() {
     stopVoiceInput?.();
     stopVoiceInput = null;
+    audioStore.resetBeeper();
   }
 
   /**

--- a/app/stores/voiceStore.js
+++ b/app/stores/voiceStore.js
@@ -23,6 +23,12 @@ export const useVoiceStore = defineStore('voice', () => {
   
   // Loopback frequency analysis - tracks dominant frequency in returned audio
   const loopbackDominantFrequency = ref(0);
+  let stopVoiceInput = null;
+
+  function stopVoiceCapture() {
+    stopVoiceInput?.();
+    stopVoiceInput = null;
+  }
 
   /**
    * Setup audio/voice for connection
@@ -30,8 +36,12 @@ export const useVoiceStore = defineStore('voice', () => {
    * @param {number} sampleRate - Current sample rate
    */
   async function setupVoiceForConnection(audioEnabled, sampleRate) {
+    stopVoiceCapture();
+    let attemptStopVoiceInput = null;
+    let captureReady = Promise.resolve();
+
     if (audioEnabled) {
-      initVoiceInput(
+      const capture = initVoiceInput(
         (data) => {
           if (connectionStore.getClient()) {
             writeVoiceData(data);
@@ -43,25 +53,43 @@ export const useVoiceStore = defineStore('voice', () => {
           debugLog('[VOICE]', translate('logentry.mic_init_error'), err);
         },
         () => {
-          audioStore.initializePersistentBeeper();
+          Promise.resolve()
+            .then(() => audioStore.initializePersistentBeeper())
+            .catch((err) => {
+              debugLog('[BEEP]', 'Optional beeper initialization failed:', err);
+            });
         }
       );
+      attemptStopVoiceInput = capture.stop;
+      captureReady = capture.ready;
+      stopVoiceInput = attemptStopVoiceInput;
     } else {
       audioStore.activateAudioLock('sample-rate', { sampleRate });
       endVoiceHandler();
     }
 
-    try {
-      await audioStore.resumeAudioContext();
-      
+    const playbackReady = (async () => {
       try {
-        await audioStore.loadAudioWorkletModule('playback-buffer-processor.js');
-      } catch (err) {
-        debugLog('[AUDIO-INIT]', 'Playback AudioWorklet pre-warm failed:', err);
+        await audioStore.resumeAudioContext();
+
+        try {
+          await audioStore.loadAudioWorkletModule('playback-buffer-processor.js');
+        } catch (err) {
+          debugLog('[AUDIO-INIT]', 'Playback AudioWorklet pre-warm failed:', err);
+        }
+      } catch (error) {
+        debugLog('[AUDIO-INIT]', 'AudioContext resume failed, continuing anyway:', error);
       }
-    } catch (error) {
-      debugLog('[AUDIO-INIT]', 'AudioContext resume failed, continuing anyway:', error);
-    }
+    })();
+
+    await Promise.all([captureReady, playbackReady]);
+
+    return () => {
+      attemptStopVoiceInput?.();
+      if (stopVoiceInput === attemptStopVoiceInput) {
+        stopVoiceInput = null;
+      }
+    };
   }
 
   /**
@@ -168,6 +196,7 @@ export const useVoiceStore = defineStore('voice', () => {
    * Reset voice state
    */
   function reset() {
+    stopVoiceCapture();
     endVoiceHandler();
     isLoopbackMode.value = false;
     voiceHandlerReady.value = false;
@@ -189,6 +218,7 @@ export const useVoiceStore = defineStore('voice', () => {
     writeVoiceData,
     getVoiceHandler,
     endVoiceHandler,
+    stopVoiceCapture,
     reset
   };
 });

--- a/app/utils/websocket-stream-lite.js
+++ b/app/utils/websocket-stream-lite.js
@@ -51,6 +51,10 @@ export default function websocketStream(target, protocols, options) {
     final(callback) {
       socket.close();
       callback();
+    },
+    destroy(error, callback) {
+      socket.close();
+      callback(error);
     }
   });
 

--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -67,15 +67,41 @@ class WorkerBasedMumbleConnector {
     });
   }
 
+  _abortError() {
+    return new DOMException("Connection aborted", "AbortError");
+  }
+
   _addCall(proxy, name, id) {
     proxy[name] = (...args) => {
       this._call(id, name, args);
     };
   }
 
-  async connect(host, args) {
-    const id = await this._query({}, "_connect", { host: host, args: args });
-    return this._client(id);
+  connect(host, args, { signal } = {}) {
+    if (signal?.aborted) {
+      return Promise.reject(this._abortError());
+    }
+
+    const reqId = this._call({}, "_connect", { host: host, args: args });
+    return new Promise((resolve, reject) => {
+      const onAbort = () => {
+        delete this._requests[reqId];
+        this._postMessage({ method: "_cancelConnect", payload: { reqId } });
+        reject(this._abortError());
+      };
+
+      this._requests[reqId] = [
+        (id) => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve(this._client(id));
+        },
+        (error) => {
+          signal?.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      ];
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   _client(id) {

--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -85,7 +85,6 @@ class WorkerBasedMumbleConnector {
     const reqId = this._call({}, "_connect", { host: host, args: args });
     return new Promise((resolve, reject) => {
       const onAbort = () => {
-        delete this._requests[reqId];
         this._postMessage({ method: "_cancelConnect", payload: { reqId } });
         reject(this._abortError());
       };
@@ -93,6 +92,12 @@ class WorkerBasedMumbleConnector {
       this._requests[reqId] = [
         (id) => {
           signal?.removeEventListener("abort", onAbort);
+          if (signal?.aborted) {
+            if (id !== null && id !== undefined) {
+              this._call({ client: id }, "disconnect", []);
+            }
+            return;
+          }
           resolve(this._client(id));
         },
         (error) => {

--- a/app/worker.js
+++ b/app/worker.js
@@ -582,6 +582,7 @@ globalThis.addEventListener("message", (ev) => {
   // - Voice stream data (has voiceId)
   const hasValidStructure = 
     (ev.data.reqId !== undefined && ev.data.method !== undefined) || // RPC call
+    ev.data.method === "_cancelConnect" || // Cancellation for a pending RPC
     ev.data.clientId !== undefined || // Client method invocation
     ev.data.voiceId !== undefined; // Voice stream chunk
   

--- a/app/worker.js
+++ b/app/worker.js
@@ -8,6 +8,7 @@ let nextClientId = 1;
 let nextVoiceId = 1;
 let voiceStreams = [];
 let clients = [];
+const pendingConnections = new Map();
 
 function postMessage(msg, transfer) {
   try {
@@ -405,9 +406,15 @@ function setupClient(id, client) {
 }
 
 function handleConnect(reqId, payload) {
+  const controller = new AbortController();
+  pendingConnections.set(reqId, controller);
   payload.args.codecs = require("./audio/codecs-browser.js");
-  mumbleConnect(payload.host, payload.args)
+  mumbleConnect(payload.host, payload.args, { signal: controller.signal })
     .then((client) => {
+      if (controller.signal.aborted) {
+        client.disconnect();
+        return null;
+      }
       let id = nextClientId++;
       clients[id] = client;
       setupClient(id, client);
@@ -423,12 +430,21 @@ function handleConnect(reqId, payload) {
     })
     .then(
       (id) => {
-        resolve(reqId, id);
+        if (!controller.signal.aborted && id !== null) {
+          resolve(reqId, id);
+        }
       },
       (err) => {
-        reject(reqId, err);
+        if (!controller.signal.aborted) {
+          reject(reqId, err);
+        }
       }
-    );
+    )
+    .finally(() => pendingConnections.delete(reqId));
+}
+
+function handleCancelConnect(payload) {
+  pendingConnections.get(payload.reqId)?.abort();
 }
 
 // Whitelist of allowed RPC methods to prevent arbitrary method invocation
@@ -443,6 +459,11 @@ const ALLOWED_CHANNEL_METHODS = new Set([
 ]);
 
 function handleClientMessage(data) {
+  if (data.method === "_cancelConnect") {
+    handleCancelConnect(data.payload);
+    return;
+  }
+
   const { clientId, userId, channelId, method, payload } = data;
   let client = clients[clientId];
 
@@ -527,6 +548,8 @@ function onMessage(data) {
   
   if (method === "_connect") {
     handleConnect(reqId, payload);
+  } else if (method === "_cancelConnect") {
+    handleCancelConnect(payload);
   } else if (data.clientId !== null && data.clientId !== undefined) {
     handleClientMessage(data);
   } else if (data.voiceId !== null && data.voiceId !== undefined) {

--- a/app/worker.js
+++ b/app/worker.js
@@ -432,11 +432,15 @@ function handleConnect(reqId, payload) {
       (id) => {
         if (!controller.signal.aborted && id !== null) {
           resolve(reqId, id);
+        } else {
+          resolve(reqId, null);
         }
       },
       (err) => {
         if (!controller.signal.aborted) {
           reject(reqId, err);
+        } else {
+          resolve(reqId, null);
         }
       }
     )

--- a/localize/en.json
+++ b/localize/en.json
@@ -19,6 +19,7 @@
         "username_in_use": "The user name you have chosen is already in use.",
         "full": "The server is full.",
         "clientcert": "The server requires you to provide a client certificate which is not supported by this web application.",
+        "generic": "The connection setup failed.",
         "server": "The server reports:"
       },
       "retry": "Retry",

--- a/tests/playwright/loopback-frequency.spec.js
+++ b/tests/playwright/loopback-frequency.spec.js
@@ -495,6 +495,27 @@ test.describe('Loopback Frequency Test', () => {
       // Use web-first assertion instead of waitForTimeout + evaluate
       await expect(connectDialogForSwitch).toBeHidden({ timeout: 2000 });
       console.log('✅ Dialog closed - switched to normal mode');
+
+      // Browsers running at 44.1 kHz require an explicit choice before the
+      // normal connection continues. At 48 kHz, Guacamole starts directly.
+      const sampleRateDialog = page.locator('.sample-rate-dialog[role="alertdialog"]');
+      const guacamoleSection = page.getByRole('region', { name: /guacamole|remote/i }).or(page.locator('section.guacamole'));
+
+      await expect.poll(async () => (
+        await sampleRateDialog.isVisible() || await guacamoleSection.isVisible()
+      ), {
+        message: 'Expected a sample-rate warning or Guacamole handoff',
+        timeout: 10000,
+      }).toBe(true);
+
+      if (await sampleRateDialog.isVisible()) {
+        console.log('   ℹ️  Sample-rate warning shown; joining without audio...');
+        const joinWithoutAudioButton = sampleRateDialog.getByRole('button', { name: /join without audio/i });
+        await expect(joinWithoutAudioButton).toBeVisible();
+        await joinWithoutAudioButton.click();
+        await expect(sampleRateDialog).toBeHidden();
+        console.log('   ✅ Continued normal connection without audio');
+      }
     });
 
     await test.step('Send chat message and verify confirmation animation', async () => {
@@ -523,13 +544,6 @@ test.describe('Loopback Frequency Test', () => {
       // Note: Animation verification is skipped in test environment because
       // the chat server may not respond, and CSS transitions are timing-sensitive
     });
-
-    console.log('\n🎉 Full test flow validated successfully!');
-    console.log('   ✅ Piano button works');
-    console.log('   ✅ Frequency detection works (440 Hz)');
-    console.log('   ✅ Display updates in real-time');
-    console.log('   ✅ Mode switching works (test → normal)');
-    console.log('   ✅ Message input works');
 
     await test.step('Verify Guacamole frame loads (expected 404 in test environment)', async () => {
       console.log('\n🖥️  Step 14: Verifying Guacamole frame loads...');
@@ -577,6 +591,14 @@ test.describe('Loopback Frequency Test', () => {
       
       console.log('✅ Guacamole frame initialization verified');
     });
+
+    console.log('\n🎉 Full test flow validated successfully!');
+    console.log('   ✅ Piano button works');
+    console.log('   ✅ Frequency detection works (440 Hz)');
+    console.log('   ✅ Display updates in real-time');
+    console.log('   ✅ Mode switching works (test → normal)');
+    console.log('   ✅ Message input works');
+    console.log('   ✅ Guacamole frame initialization works');
 
     console.log('\n🧹 Cleaning up resources...');
     await page.evaluate(() => {


### PR DESCRIPTION
## Goal

Make the authenticated login-to-desktop handoff reliable, especially when a login, logout, retry, or connection attempt overlaps with an older one.

From a user's perspective, the problem was inconsistent state: Flexpair could appear logged in and then fall back to login, a retry could be affected by work left over from the previous attempt, or a manual logout could be needed before a usable session started.

## What changed and why

This PR treats each login and connection attempt as one owned lifecycle. Starting a new attempt or logging out invalidates and actively stops the previous one.

### 1. Credentials now belong to the current login

Credential cache entries and in-flight credential requests are tied to the current authentication token. A response from an older login can no longer overwrite or satisfy the newer session.

**Why this is necessary:** logging out and back in quickly could otherwise reuse credentials or a delayed response from the previous identity.

### 2. Only the newest connection attempt may complete

A new connect, retry, cancellation, or logout invalidates the previous attempt. Cancellation now propagates through the worker and Mumble WebSocket handshake, and a client that arrives late is disconnected instead of becoming the active client.

**Why this is necessary:** ignoring an old result in the UI was not enough; its background connection could remain alive and interfere with the next login.

### 3. Logout cleanup cannot overtake the next login

Audio suspension and resumption are serialized, connection-owned voice resources are cleaned up in order, and reauthentication no longer waits indefinitely for a logout promise.

**Why this is necessary:** asynchronous cleanup from the old session could finish after the new session had started, leaving audio suspended or the login UI blocked.

### 4. The final desktop handoff fails clearly instead of stalling

The Guacamole frame starts eagerly and is tracked reactively. Audio/voice setup is inside the same error boundary as the connection, so local setup failures produce an actionable error rather than looking like a server refusal or silently stopping the handoff.

**Why this is necessary:** successful authentication alone is not a usable session; Mumble, audio, and the desktop frame must all complete under the same current attempt.

### 5. Existing audio-test behavior is preserved

The connection reset keeps the Audio Test active while its loopback connection is being established.

## Expected result

- A stale login or credential response cannot replace the current session.
- An old connection cannot become active after a retry or logout.
- Cleanup from the previous session cannot undo the new session's audio state.
- Reauthentication returns to a usable login flow even if provider logout hangs.
- Setup failures are shown explicitly instead of leaving the user in an ambiguous state.

The practical outcome should be that users no longer need the "log out first, then log in again" workaround to recover from an inconsistent handoff.

## Verification

- Jest: 62 suites passed; 1,843 tests passed; 1 existing todo.
- Python auth-server tests: 40 passed.
- Production build: passed.
- Dependency check: passed.
- Dependency audit: 0 vulnerabilities.
- `git diff --check`: passed.
- Regression coverage added for credential invalidation, concurrent/stale attempts, worker and WebSocket cancellation, late clients, audio ownership, logout/reauthentication, error presentation, Guacamole startup, and the Audio Test state.

The Playwright loopback test still requires the repository's local Docker/nginx/Mumble environment. In the current host environment it stopped at navigation to `local.flexpair.app`; it did not reach an application assertion. The focused Audio Test regression and the complete Jest suite pass.

## Review and risk

**Risk: medium.** This changes timing-sensitive authentication, connection, and cleanup paths. The implementation is spread across those layers because cancellation must reach the resources that can otherwise outlive an obsolete attempt. The risk is bounded by explicit attempt ownership, active cancellation, and regression tests for the relevant races.

The PR does not introduce Auth0 or a new Netlify dependency, and it does not change pricing, infrastructure, or deployment configuration.

No credentials or other secrets are included in this pull request.