### PR TITLE
fix: address Sonar findings on lite

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies for audit and tests
-        run: npm ci || npm i
+        run: npm ci --ignore-scripts
 
       - name: Security audit gate
         run: npm run audit:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Playwright system dependencies for Chromium
 # Required for automated loopback frequency tests
-RUN npx playwright install-deps chromium
+RUN ./node_modules/.bin/playwright install-deps chromium
 
 # GitHub Codespaces' SSH broker targets its built-in `codespace` user and home.
 RUN usermod --login codespace --home /home/codespace --move-home node \

--- a/__tests__/utils/stream-utils.test.js
+++ b/__tests__/utils/stream-utils.test.js
@@ -48,7 +48,7 @@ describe('websocket-stream-lite', () => {
   it('should create stream from WebSocket URL', () => {
     const stream = websocketStream('wss://example.com');
     
-    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com', undefined);
+    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com/', undefined);
     expect(stream).toBeDefined();
     expect(stream.socket).toBe(mockSocket);
   });
@@ -60,6 +60,13 @@ describe('websocket-stream-lite', () => {
     expect(stream.socket).toBe(existingSocket);
   });
 
+  it('should reject non-WebSocket URLs', () => {
+    expect(() => websocketStream('https://example.com')).toThrow(
+      'WebSocket target must use ws: or wss:'
+    );
+    expect(globalThis.WebSocket).not.toHaveBeenCalled();
+  });
+
   it('should set binaryType to arraybuffer for new sockets', () => {
     websocketStream('wss://example.com');
     
@@ -69,13 +76,13 @@ describe('websocket-stream-lite', () => {
   it('should handle protocols parameter', () => {
     websocketStream('wss://example.com', ['proto1', 'proto2']);
     
-    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com', ['proto1', 'proto2']);
+    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com/', ['proto1', 'proto2']);
   });
 
   it('should handle options object as second parameter', () => {
     websocketStream('wss://example.com', { protocol: 'mumble' });
     
-    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com', 'mumble');
+    expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com/', 'mumble');
   });
 
   it('should send data through write()', (done) => {

--- a/app/index.js
+++ b/app/index.js
@@ -154,9 +154,7 @@ function applyQueryParamsToConnectDialog() {
   const configuredHosts = globalThis.mumbleWebConfig.allowedServerHosts;
   const allowedHosts = Array.isArray(configuredHosts)
     ? configuredHosts
-    : configuredHosts
-      ? [configuredHosts]
-      : [globalThis.location.hostname];
+    : configuredHosts ? [configuredHosts] : [globalThis.location.hostname];
   const addressFromQuery = urlObj.searchParams.get('address');
   const { address, rejected } = resolveConnectAddress(
     addressFromQuery,
@@ -171,7 +169,10 @@ function applyQueryParamsToConnectDialog() {
   }
 
   if (queryParams.port) {
-    dialogStore.connectDialog.port = queryParams.port;
+    const allowedPort = /^(?:\d{1,5})(?:\/[^?#]*)?$/.test(queryParams.port);
+    if (allowedPort) {
+      dialogStore.connectDialog.port = queryParams.port;
+    }
   }
   // Password is no longer accepted from URL for security reasons
   // It is fetched from the auth server after successful authentication

--- a/app/index.js
+++ b/app/index.js
@@ -169,9 +169,11 @@ function applyQueryParamsToConnectDialog() {
   }
 
   if (queryParams.port) {
-    const allowedPort = /^(?:\d{1,5})(?:\/[^?#]*)?$/.test(queryParams.port);
+    const portMatch = /^(\d{1,5})(?:\/[^?#]*)?$/.exec(String(queryParams.port));
+    const portNumber = portMatch ? Number.parseInt(portMatch[1], 10) : 0;
+    const allowedPort = portMatch !== null && portNumber >= 1 && portNumber <= 65535;
     if (allowedPort) {
-      dialogStore.connectDialog.port = queryParams.port;
+      dialogStore.connectDialog.port = String(queryParams.port);
     }
   }
   // Password is no longer accepted from URL for security reasons

--- a/app/utils/websocket-stream-lite.js
+++ b/app/utils/websocket-stream-lite.js
@@ -26,7 +26,11 @@ export default function websocketStream(target, protocols, options) {
   if (typeof target === 'object' && target.send) {
     socket = target;
   } else {
-    socket = new WebSocket(target, protocols);
+    const socketUrl = new URL(target);
+    if (socketUrl.protocol !== 'ws:' && socketUrl.protocol !== 'wss:') {
+      throw new TypeError('WebSocket target must use ws: or wss:');
+    }
+    socket = new WebSocket(socketUrl.href, protocols);
     socket.binaryType = 'arraybuffer';
   }
 

--- a/tests/playwright/loopback-frequency.spec.js
+++ b/tests/playwright/loopback-frequency.spec.js
@@ -66,7 +66,8 @@ test.describe('Loopback Frequency Test', () => {
     // Navigate to app with debug-audio for detailed audio pipeline logging
     console.log('🌐 Navigating to application...');
     
-    await page.goto('/?debug-audio', { waitUntil: 'networkidle', timeout: 30000 });
+    await page.goto('/?debug-audio', { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await expect(page.locator('body')).toBeVisible();
     
     // Handle the GitHub Codespaces interstitial only when the current page is
     // actually on the forwarded Codespaces domain. This avoids false positives
@@ -85,7 +86,7 @@ test.describe('Loopback Frequency Test', () => {
         if (await continueButton.isVisible({ timeout: 2000 }).catch(() => false)) {
           console.log('✅ Found Codespaces interstitial action, clicking...');
           await continueButton.click();
-          await page.waitForLoadState('networkidle', { timeout: 10000 });
+          await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
           console.log('✅ Passed Codespaces interstitial');
         } else {
           console.log('ℹ️  No Codespaces interstitial action button found');

--- a/tests/playwright/loopback-frequency.spec.js
+++ b/tests/playwright/loopback-frequency.spec.js
@@ -86,7 +86,7 @@ test.describe('Loopback Frequency Test', () => {
         if (await continueButton.isVisible({ timeout: 2000 }).catch(() => false)) {
           console.log('✅ Found Codespaces interstitial action, clicking...');
           await continueButton.click();
-          await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+          await expect(continueButton).toHaveCount(0, { timeout: 10000 });
           console.log('✅ Passed Codespaces interstitial');
         } else {
           console.log('ℹ️  No Codespaces interstitial action button found');


### PR DESCRIPTION
## Summary
- validate connection targets and WebSocket schemes before opening streams
- harden query-parameter handling and replace flaky Playwright waits with web-first assertions
- make dependency and Playwright installation steps deterministic for the lite workflow and dev image

## Verification
- `npm run test:unit` — 63 suites, 1,862 tests passed
- `npm run build` — passed
- `npm run audit:ci` — 0 vulnerabilities
- `npm run check:deps` — passed
- `npm run test:python` — 40 tests passed
- `git diff --check` — passed

Target branch: `lite`.
