### PR TITLE
fix: harden WebSocket stream targets

### DIFF
--- a/__tests__/utils/stream-utils.test.js
+++ b/__tests__/utils/stream-utils.test.js
@@ -85,6 +85,18 @@ describe('websocket-stream-lite', () => {
     expect(globalThis.WebSocket).toHaveBeenCalledWith('wss://example.com/', 'mumble');
   });
 
+  it('should reject credentials in a WebSocket URL', () => {
+    expect(() => websocketStream('wss://user:password@example.com')).toThrow(
+      'WebSocket target must not include credentials or a custom port'
+    );
+  });
+
+  it('should reject a custom port in a WebSocket URL', () => {
+    expect(() => websocketStream('wss://example.com:8443')).toThrow(
+      'WebSocket target must not include credentials or a custom port'
+    );
+  });
+
   it('should send data through write()', (done) => {
     // Create stream from existing socket to ensure it's already OPEN
     const existingSocket = {

--- a/app/utils/websocket-stream-lite.js
+++ b/app/utils/websocket-stream-lite.js
@@ -30,6 +30,9 @@ export default function websocketStream(target, protocols, options) {
     if (socketUrl.protocol !== 'ws:' && socketUrl.protocol !== 'wss:') {
       throw new TypeError('WebSocket target must use ws: or wss:');
     }
+    if (socketUrl.username || socketUrl.password || socketUrl.port) {
+      throw new TypeError('WebSocket target must not include credentials or a custom port');
+    }
     socket = new WebSocket(socketUrl.href, protocols);
     socket.binaryType = 'arraybuffer';
   }
@@ -45,7 +48,9 @@ export default function websocketStream(target, protocols, options) {
       
       try {
         // Convert to ArrayBuffer if needed
-        const data = chunk.buffer ? chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength) : chunk;
+        const data = Buffer.isBuffer(chunk)
+          ? chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength)
+          : chunk;
         socket.send(data);
         callback();
       } catch (err) {


### PR DESCRIPTION
## Summary
- reject WebSocket targets containing credentials or custom ports
- only treat actual Buffer instances as Node buffers before sending
- add regression tests for both rejected target forms

## Verification
- `SKIP_PREPARE=1 npm run test:unit -- --runInBand` — passed (63 suites, 1,864 tests)
- `npm run build:local` — bundle build passed; local dev-server startup is blocked because this host has no `MUMBLE_SERVER` environment variable

Draft only; target branch is `lite`.