### PR TITLE
fix: bound js-yaml override to major version four

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4516,6 +4516,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/depcheck/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/depcheck/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/deps-regex": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "ws": "8.21.3",
     "magic-string": "0.30.10",
     "js-yaml": ">=4.3.2 <5",
+    "depcheck": {
+      "js-yaml": "3.15.2"
+    },
     "@babel/core": "7.29.7",
     "linkify-it": "5.0.2",
     "markdown-it": "14.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "baseline-browser-mapping": "2.11.20",
     "ws": "8.21.3",
     "magic-string": "0.30.10",
-    "js-yaml": ">=4.3.2",
+    "js-yaml": ">=4.3.2 <5",
     "@babel/core": "7.29.7",
     "linkify-it": "5.0.2",
     "markdown-it": "14.3.0"


### PR DESCRIPTION
## Summary
- keep the global `js-yaml` override at `>=4.3.2 <5`
- keep `depcheck@1.4.7` on `js-yaml@3.15.2`

`depcheck@1.4.7` declares `js-yaml@^3.14.1` and calls `js-yaml.safeLoad()`. In js-yaml 4.3.2, `safeLoad` is only a compatibility stub that throws because the usable API was removed in 4.0.0. js-yaml 5.x is incompatible as well. The nested override therefore keeps depcheck on the compatible 3.x line.

`@istanbuljs/load-nyc-config@1.1.0` declares `js-yaml@^3.13.1` but calls `yaml.load()`. Its current resolved `js-yaml@4.3.2` supports that API, so the global secure 4.x override remains suitable for the Jest/coverage path. The two consumers are intentionally resolved to separate versions.

## Verification
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm ls js-yaml --all` — depcheck uses `3.15.2`; Jest/coverage tooling uses `4.3.2`
- direct API probes — `depcheck`'s `safeLoad()` works; `js-yaml@4.3.2`'s removed `safeLoad()` path throws as expected
- `npm run check:deps`
- `npm run audit:ci`
- `npm run test:unit -- --runInBand`
- `npm run build`
- GitHub Actions: Docker, CodeQL, Advanced Security, and SonarCloud all pass
- Copilot review approved the current head
